### PR TITLE
Make sure Duration exists in the settings

### DIFF
--- a/server/src/main/java/de/tum/cit/aet/thesis/service/ThesisPresentationService.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/service/ThesisPresentationService.java
@@ -378,7 +378,7 @@ public class ThesisPresentationService {
                         "Details: " + clientHost + "/presentations/" + presentation.getId() + "\n\n" +
                         "Abstract:\n" + thesis.getAbstractField(),
                 presentation.getScheduledAt(),
-                presentation.getScheduledAt().plus(groupSettings != null ? groupSettings.getPresentationSlotDuration() : 30, ChronoUnit.MINUTES),
+                presentation.getScheduledAt().plus(groupSettings != null && groupSettings.getPresentationSlotDuration() != null  ? groupSettings.getPresentationSlotDuration() : 30, ChronoUnit.MINUTES),
                 this.applicationMail,
                 thesis.getRoles().stream().map(role -> role.getUser().getEmail()).toList(),
                 presentation.getInvites().stream().map(ThesisPresentationInvite::getEmail).toList()


### PR DESCRIPTION
Even when there are Researchgroup Settings exist does not mean that the Presentation Duration was ever changed

We need to use the default also when those are null