### PR TITLE
Update Development doc

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -110,7 +110,11 @@ To apply these, navigate to:
 cd ../server/src/main/resources/db/changelog/manual/
 ```
 
-And execute all files that you need.
+And execute all files that you need, e.g.,
+
+```bash
+docker compose exec -T db psql -U thesis-management-postgres -d thesis-management < insert_tum_aet_email_templates.sql
+```
 
 > 💡 Tip: Check the prerequisites !
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -4,6 +4,43 @@
 
 ![Architecture](files/subsystem-decomposition.svg)
 
+## Quick Start
+To set up the development environment for the Thesis Management System, follow the steps below.
+
+1. Start Support Services using Docker Compose
+
+    ```bash
+    docker compose up -d
+    ```
+
+2. Import Initial Test Data into the Database
+
+    ```bash
+    docker compose exec -T db psql -U thesis-management-postgres -d thesis-management < server/src/main/resources/db/changelog/manual/init.sql
+    ```
+
+3. Start the Server Application
+
+    ```bash
+    cd server
+    ./gradlew bootRun
+    ```
+
+4. Start the Client Application
+
+    ```bash
+    cd ../client
+    npm install
+    npm run dev
+    ```
+
+5. Access the Application
+
+    - Client: [http://localhost:3000](http://localhost:3000)
+    - Server API: [http://localhost:8080](http://localhost:8080)
+    - Keycloak Admin Console: [http://localhost:8081](http://localhost:8081)
+    - **Use the test users provided in section [Keycloak](#keycloak).**
+
 ## Support Services
 
 The easiest way to set up the development environment is to use Docker Compose. From the project root, run:
@@ -42,9 +79,20 @@ Details can be found in the admin console in the realm [thesis-management](http:
 
 > 💡 Tip: Make sure the database container is running (`docker compose up db -d`) before executing the commands.
 
+### Importing Test Data
+
+To use the Keycloak test users, you need to import initial test data into the database.
+Run the following command from the project root:
+
+```bash
+docker compose exec -T db psql -U thesis-management-postgres -d thesis-management < server/src/main/resources/db/changelog/manual/init.sql
+```
+
+This will insert the four test users (admin, supervisor, advisor, student) into the `users` table and creates a sample research group which is led by the supervisor user.
+
 ### Liquibase Migration
 
-To apply the latest database schema changes using Liquibase, run the following command:
+Whenever there are changes to the database schema or initial data, these are managed via Liquibase migrations. To apply the latest migrations to your local database, navigate to the `server` folder and run:
 
 ```bash
 cd ../server
@@ -53,29 +101,20 @@ cd ../server
 
 This will apply all migrations defined under `server/src/main/resources/db/changelog/changes`.
 
-### Importing Test Data
+### Additional Test Data
 
-To populate the database with test data, go to the manual migration folder:
+Optional test data such as more email templates, research groups, and users can be found in the `manual` folder. \
+To apply these, navigate to:
 
 ```bash
 cd ../server/src/main/resources/db/changelog/manual/
 ```
 
 And execute all files that you need.
+
 > 💡 Tip: Check the prerequisites !
 
 > 💡 Tip: Default Templates are needed for many API calls.
-
-#### Example Users and Roles
-
-| Username       | First Name | Last Name | Email                      | Role       |
-|----------------|------------|-----------|----------------------------|------------|
-| sam_fischer    | Sam        | Fischer   | <sam_fischer@gmail.com>    | supervisor |
-| jane_doe       | Jane       | Doe       | <jane_doe@gmail.com>       | supervisor |
-| joey_read      | Joey       | Read      | <joey_read@gmail.com>      | advisor    |
-| barney_young   | Barney     | Young     | <barney_young@gmail.com>   | advisor    |
-| chloe_mitchell | Chloe      | Mitchell  | <chloe_mitchell@gmail.com> | student    |
-| kelly_wilkins  | Kelly      | Wilkins   | <kelly_wilkins@gmail.com>  | student    |
 
 ## Postfix
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -4,30 +4,39 @@
 
 ![Architecture](files/subsystem-decomposition.svg)
 
+## Support Services
+
+The easiest way to set up the development environment is to use Docker Compose. From the project root, run:
+
+```bash
+docker compose up -d
+```
+
+This command will start necessary support services:
+
+- PostgreSQL Database (Port: 5144)
+- Keycloak (Port: 8081)
+- Radicale CalDav Server (Port: 5232)
+
 ## Keycloak
 
-For local development start a keycloak container by following the steps below:
-1. From the project root execute:
-```
-docker compose up keycloak -d
-```
-2. Open http://localhost:8081 and sign in with admin credentials
-    * Username: `admin`
-    * Password: `admin`
-3. Click on the menu in the top left and go to [Manage realm](http://localhost:8081/admin/master/console/#/master/realms)
-4. Click on "Create realm", a popup appears
-5. Import the [keycloak-realm-config-example-json](/keycloak-realm-config-example.json) using drag and drop (alternatively, you can also create a new realm `thesis-management` manually)
-6. Select the newly created realm and create your user in [Users](http://localhost:8081/admin/master/console/#/thesis-management/users) (username, email, first name, last name)
-7. Go to "Credentials" for the new user and set a password (disable "Temporary" to avoid being forced to change it on first login)
-8. Go to "Role mapping" and assign the client roles `admin`, `supervisor`, `advisor` to the new user
-   * Select "Filter by clients" and search for "thesis-management-app" to find the roles
+The Keycloak console is accessible at [http://localhost:8081](http://localhost:8081). \
+Use the following admin credentials to log in:
 
-## PostgreSQL Database
+- **Username:** admin
+- **Password:** admin
 
-For local development start a database container by executing the following command from the project root:
-```
-docker compose up db -d
-```
+On startup, the `thesis-management` realm is automatically imported from [thesis-management-realm.json](/keycloak/thesis-management-realm.json).
+The realm includes test users with the following credentials:
+
+| Username   | Email                   | Password   | Role       |
+|------------|-------------------------|------------|------------|
+| admin      | <admin@test.local>      | admin      | admin      |
+| supervisor | <supervisor@test.local> | supervisor | supervisor |
+| advisor    | <advisor@test.local>    | advisor    | advisor    |
+| student    | <student@test.local>    | student    | student    |
+
+Details can be found in the admin console in the realm [thesis-management](http://localhost:8081/admin/master/console/#/thesis-management).
 
 ## Database Setup and Test Data
 
@@ -59,14 +68,14 @@ And execute all files that you need.
 
 #### Example Users and Roles
 
-| Username       | First Name | Last Name | Email                    | Role       |
-|----------------|------------|-----------|--------------------------|------------|
-| sam_fischer    | Sam        | Fischer   | sam_fischer@gmail.com    | supervisor |
-| jane_doe       | Jane       | Doe       | jane_doe@gmail.com       | supervisor |
-| joey_read      | Joey       | Read      | joey_read@gmail.com      | advisor    |
-| barney_young   | Barney     | Young     | barney_young@gmail.com   | advisor    |
-| chloe_mitchell | Chloe      | Mitchell  | chloe_mitchell@gmail.com | student    |
-| kelly_wilkins  | Kelly      | Wilkins   | kelly_wilkins@gmail.com  | student    |
+| Username       | First Name | Last Name | Email                      | Role       |
+|----------------|------------|-----------|----------------------------|------------|
+| sam_fischer    | Sam        | Fischer   | <sam_fischer@gmail.com>    | supervisor |
+| jane_doe       | Jane       | Doe       | <jane_doe@gmail.com>       | supervisor |
+| joey_read      | Joey       | Read      | <joey_read@gmail.com>      | advisor    |
+| barney_young   | Barney     | Young     | <barney_young@gmail.com>   | advisor    |
+| chloe_mitchell | Chloe      | Mitchell  | <chloe_mitchell@gmail.com> | student    |
+| kelly_wilkins  | Kelly      | Wilkins   | <kelly_wilkins@gmail.com>  | student    |
 
 ## Postfix
 
@@ -75,29 +84,33 @@ Notice: local development does not support mailing functionality. The mails are 
 ## Server
 
 ### Preconditions
-* Database available at `jdbc:postgresql://db:5144/thesis-management`
-* Keycloak realm `thesis-management` is available under http://localhost:8081 (See [Keycloak Setup](#keycloak-setup))
+
+- Database available at `jdbc:postgresql://db:5144/thesis-management`
+- Keycloak realm `thesis-management` is available under <http://localhost:8081>
 
 To start the sever application for local development, navigate to /server folder and execute the following command from the terminal:
-```
+
+```bash
 ./gradlew bootRun
 ```
 
-Server is served at http://localhost:8080.
+Server is served at <http://localhost:8080>.
 
 ## Client
 
-#### Preconditions
-* Server running at http://localhost:8080
-* Keycloak realm `thesis-management` is available under http://localhost:8081 (See [Keycloak Setup](#keycloak-setup))
+### Preconditions
+
+- Server running at <http://localhost:8080>
+- Keycloak realm `thesis-management` is available under <http://localhost:8081>
 
 To start the client application for local development, navigate to /client folder and execute the following command from the terminal:
-```
+
+```bash
 npm install
 npm run dev
 ```
 
-Client is served at http://localhost:3000. 
+Client is served at <http://localhost:3000>.
 
 ## Postman Collection
 
@@ -106,9 +119,9 @@ A ready-to-use Postman Collection is included: [`TUMApply API.postman_collection
 ### Key Features
 
 - ✅ **Pre-configured OAuth2 Authentication**  
-  The collection handles the full OAuth2 flow using Keycloak. When sending a request, Postman 
-  will automatically open a login window (otherwise go to the Collection > Authorization > Click 
-  on "Get New Access Token" at the bottom) if the token is missing or expired. Token refresh is 
+  The collection handles the full OAuth2 flow using Keycloak. When sending a request, Postman
+  will automatically open a login window (otherwise go to the Collection > Authorization > Click
+  on "Get New Access Token" at the bottom) if the token is missing or expired. Token refresh is
   also handled automatically.
 
 - ✅ **Collection-Level Configuration**  
@@ -121,7 +134,6 @@ A ready-to-use Postman Collection is included: [`TUMApply API.postman_collection
 
 1. Open Postman and click **Import** on the top left.
 2. Upload the provided [`TUMApply API.postman_collection.json`](./Thesis%20Management%20API.postman_collection.json).
-   postman_collection.json).
 3. The collection will appear in the sidebar.
 4. Start sending requests — OAuth2 authentication will be handled automatically.
 

--- a/server/src/main/resources/db/changelog/manual/init.sql
+++ b/server/src/main/resources/db/changelog/manual/init.sql
@@ -1,0 +1,173 @@
+DO
+$$
+    DECLARE
+        iecs_research_group_id UUID := gen_random_uuid();
+        iecs_head_id UUID := gen_random_uuid();
+BEGIN
+-- Add Sample Research Group (without head_user_id initially)
+INSERT INTO
+    research_groups (
+        research_group_id,
+        head_user_id,
+        name,
+        abbreviation,
+        description,
+        website_url,
+        campus,
+        created_at,
+        created_by,
+        updated_at,
+        updated_by,
+        archived
+    )
+VALUES
+    (
+        iecs_research_group_id,
+        NULL,
+        'Institute for Excellence in Computer Science',
+        'IECS',
+        'The Institute for Excellence in Computer Science (IECS) is dedicated to research and education in the most excellent areas of computer science.',
+        'https://www.iecs.example.edu',
+        'Munich - Garching',
+        NOW (),
+        NULL,
+        NOW (),
+        NULL,
+        FALSE
+    );
+
+-- Add Sample Users
+INSERT INTO
+    users (
+        user_id,
+        university_id,
+        matriculation_number,
+        email,
+        first_name,
+        last_name,
+        gender,
+        nationality,
+        cv_filename,
+        degree_filename,
+        examination_filename,
+        study_degree,
+        study_program,
+        projects,
+        interests,
+        special_skills,
+        enrolled_at,
+        updated_at,
+        joined_at,
+        custom_data,
+        avatar,
+        research_group_id
+    )
+VALUES
+    (
+        gen_random_uuid (),
+        'admin',
+        10000000,
+        'admin@test.local',
+        'Admin',
+        'User',
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NOW (),
+        NOW (),
+        NOW (),
+        NULL,
+        NULL,
+        NULL
+    ),
+    (
+        iecs_head_id,
+        'supervisor',
+        10000001,
+        'supervisor@test.local',
+        'Supervisor',
+        'User',
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NOW (),
+        NOW (),
+        NOW (),
+        NULL,
+        NULL,
+        iecs_research_group_id
+    ),
+    (
+        gen_random_uuid (),
+        'advisor',
+        10000002,
+        'advisor@test.local',
+        'Advisor',
+        'User',
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NOW (),
+        NOW (),
+        NOW (),
+        NULL,
+        NULL,
+        iecs_research_group_id
+    ),
+    (
+        gen_random_uuid (),
+        'student',
+        20000001,
+        'student@test.local',
+        'Student',
+        'One',
+        'MALE',
+        'DE',
+        NULL,
+        NULL,
+        NULL,
+        'MASTER',
+        'COMPUTER_SCIENCE',
+        'AI-based tutor recommendation system',
+        'Educational technology, backend development',
+        'Java, Spring Boot, PostgreSQL',
+        NOW (),
+        NOW (),
+        NOW (),
+        NULL,
+        NULL,
+        NULL
+    )
+;
+
+-- Update Research Group with head_user_id
+UPDATE research_groups
+SET head_user_id = iecs_head_id,
+    created_by = iecs_head_id,
+    updated_by = iecs_head_id
+WHERE research_group_id = iecs_research_group_id;
+
+END;
+
+$$ LANGUAGE PLPGSQL;


### PR DESCRIPTION
**Development Environment Setup:**
Since ea9d83a973c9555c85b496a6b02b64819ba343ac the Keycloak realm `thesis-management` is automatically loaded on compose startup. Therefore the instructions in docs/DEVELOPMENT.md to setup the realm manually is obsolete. Changed the section to include the test users.

**New DB Test data:**
Adds `init.sql` which adds the users matching the ones in the Keycloak realm. Needed to avoid warnings when logging in with Keycloak.

**Quick Start Section:**
Adds a section to the Development doc with step by step instructions to get the environment setup as fast as possible.

**Minor Corrections:**

- Fixed several minor Markdown formatting issues
- Fixed a minor typo in the Postman Collection import instructions.