### PR TITLE
Update role labels in UI to align with CIT terminology

### DIFF
--- a/client/src/components/ThesesTable/ThesesTable.tsx
+++ b/client/src/components/ThesesTable/ThesesTable.tsx
@@ -65,13 +65,13 @@ const ThesesTable = (props: IThesesTableProps) => {
     },
     supervisors: {
       accessor: 'supervisors',
-      title: 'Supervisor',
+      title: 'Examiner',
       width: 180,
       render: (thesis) => <AvatarUserList users={thesis.supervisors} />,
     },
     advisors: {
       accessor: 'advisors',
-      title: 'Advisor(s)',
+      title: 'Supervisor(s)',
       ellipsis: true,
       width: 180,
       render: (thesis) => <AvatarUserList users={thesis.advisors} />,

--- a/client/src/components/ThesisData/ThesisData.tsx
+++ b/client/src/components/ThesisData/ThesisData.tsx
@@ -37,13 +37,13 @@ const ThesisData = (props: IThesisDataProps) => {
       <Grid>
         <Grid.Col span={{ md: 4 }}>
           <LabeledItem
-            label={pluralize('Supervisor', thesis.supervisors.length)}
+            label={pluralize('Examiner', thesis.supervisors.length)}
             value={<AvatarUserList users={thesis.supervisors} withUniversityId={true} />}
           />
         </Grid.Col>
         <Grid.Col span={{ md: 4 }}>
           <LabeledItem
-            label={pluralize('Advisor', thesis.advisors.length)}
+            label={pluralize('Supervisor', thesis.advisors.length)}
             value={<AvatarUserList users={thesis.advisors} withUniversityId={true} />}
           />
         </Grid.Col>

--- a/client/src/components/TopicData/TopicData.tsx
+++ b/client/src/components/TopicData/TopicData.tsx
@@ -18,13 +18,13 @@ const TopicData = (props: ITopicDataProps) => {
       <Grid>
         <Grid.Col span={{ md: 3 }}>
           <LabeledItem
-            label={pluralize('Supervisor', topic.supervisors.length)}
+            label={pluralize('Examiner', topic.supervisors.length)}
             value={<AvatarUserList users={topic.supervisors} />}
           />
         </Grid.Col>
         <Grid.Col span={{ md: 3 }}>
           <LabeledItem
-            label={pluralize('Advisor', topic.advisors.length)}
+            label={pluralize('Supervisor', topic.advisors.length)}
             value={<AvatarUserList users={topic.advisors} />}
           />
         </Grid.Col>

--- a/client/src/components/TopicsTable/TopicsTable.tsx
+++ b/client/src/components/TopicsTable/TopicsTable.tsx
@@ -83,14 +83,14 @@ const TopicsTable = (props: ITopicsTableProps) => {
     },
     supervisor: {
       accessor: 'supervisor',
-      title: 'Supervisor',
+      title: 'Examiner',
       width: 180,
       ellipsis: true,
       render: (topic) => <AvatarUserList users={topic.supervisors} />,
     },
     advisor: {
       accessor: 'advisor',
-      title: 'Advisor(s)',
+      title: 'Supervisor(s)',
       width: 180,
       ellipsis: true,
       render: (topic) => <AvatarUserList users={topic.advisors} />,

--- a/client/src/pages/BrowseThesesPage/components/CreateThesisModal/CreateThesisModal.tsx
+++ b/client/src/pages/BrowseThesesPage/components/CreateThesisModal/CreateThesisModal.tsx
@@ -162,13 +162,13 @@ const CreateThesisModal = (props: ICreateThesisModalProps) => {
             {...form.getInputProps('students')}
           />
           <UserMultiSelect
-            label='Advisor(s)'
+            label='Supervisor(s)'
             required={true}
             groups={['advisor', 'supervisor']}
             {...form.getInputProps('advisors')}
           />
           <UserMultiSelect
-            label='Supervisor'
+            label='Examiner'
             required={true}
             groups={['supervisor']}
             maxValues={1}

--- a/client/src/pages/LandingPage/components/PublishedTheses/PublishedTheses.tsx
+++ b/client/src/pages/LandingPage/components/PublishedTheses/PublishedTheses.tsx
@@ -110,7 +110,7 @@ const PublishedTheses = ({ search, representationType, filters, limit }: Publish
           },
           {
             accessor: 'advisors',
-            title: 'Advisor(s)',
+            title: 'Supervisor(s)',
             ellipsis: true,
             width: 180,
             render: (thesis) => <AvatarUserList users={thesis.advisors} />,

--- a/client/src/pages/ManageTopicsPage/components/ReplaceTopicModal/ReplaceTopicModal.tsx
+++ b/client/src/pages/ManageTopicsPage/components/ReplaceTopicModal/ReplaceTopicModal.tsx
@@ -205,7 +205,7 @@ const ReplaceTopicModal = (props: ICreateTopicModalProps) => {
             {...form.getInputProps('thesisTypes')}
           />
           <UserMultiSelect
-            label='Supervisor'
+            label='Examiner'
             required
             groups={['supervisor']}
             initialUsers={topic?.supervisors}
@@ -213,7 +213,7 @@ const ReplaceTopicModal = (props: ICreateTopicModalProps) => {
             {...form.getInputProps('supervisorIds')}
           />
           <UserMultiSelect
-            label='Advisor(s)'
+            label='Supervisor(s)'
             required
             groups={['advisor', 'supervisor']}
             initialUsers={topic?.advisors}

--- a/client/src/pages/ReplaceApplicationPage/components/SelectTopicStep/components/CollapsibleTopicElement.tsx
+++ b/client/src/pages/ReplaceApplicationPage/components/SelectTopicStep/components/CollapsibleTopicElement.tsx
@@ -63,7 +63,7 @@ const CollapsibleTopicElement = ({ topic, onApply }: ICollapsibleTopicElementPro
                   <Grid.Col span={4}>
                     {topic.supervisors.length > 0 && (
                       <LabeledItem
-                        label={pluralize('Supervisor', topic.supervisors.length)}
+                        label={pluralize('Examiner', topic.supervisors.length)}
                         value={<AvatarUserList users={topic.supervisors} size='xs' />}
                       />
                     )}
@@ -71,7 +71,7 @@ const CollapsibleTopicElement = ({ topic, onApply }: ICollapsibleTopicElementPro
                   <Grid.Col span={8}>
                     {topic.advisors.length > 0 && (
                       <LabeledItem
-                        label={pluralize('Advisor', topic.advisors.length)}
+                        label={pluralize('Supervisor', topic.advisors.length)}
                         value={<AvatarUserList users={topic.advisors} size='xs' />}
                       />
                     )}

--- a/client/src/pages/ResearchGroupSettingPage/components/ResearchGroupMembers.tsx
+++ b/client/src/pages/ResearchGroupSettingPage/components/ResearchGroupMembers.tsx
@@ -268,8 +268,8 @@ const ResearchGroupMembers = ({ researchGroupData }: IResearchGroupMembersProps)
                     <Box style={{ minWidth: 140, maxWidth: 200 }}>
                       <Select
                         data={[
-                          { value: 'advisor', label: 'Advisor' },
-                          { value: 'supervisor', label: 'Supervisor' },
+                          { value: 'advisor', label: 'Supervisor' },
+                          { value: 'supervisor', label: 'Examiner' },
                         ]}
                         value={getPrimaryRoleFromGroups(member.groups)}
                         onChange={(val) => {

--- a/client/src/pages/ThesisPage/components/ThesisConfigSection/ThesisConfigSection.tsx
+++ b/client/src/pages/ThesisPage/components/ThesisConfigSection/ThesisConfigSection.tsx
@@ -307,7 +307,7 @@ const ThesisConfigSection = () => {
               <UserMultiSelect
                 required={true}
                 disabled={!access.advisor}
-                label='Advisor(s)'
+                label='Supervisor(s)'
                 groups={['advisor', 'supervisor']}
                 initialUsers={thesis.advisors}
                 {...form.getInputProps('advisors')}
@@ -315,7 +315,7 @@ const ThesisConfigSection = () => {
               <UserMultiSelect
                 required={true}
                 disabled={!access.advisor}
-                label='Supervisor'
+                label='Examiner'
                 groups={['supervisor']}
                 initialUsers={thesis.supervisors}
                 maxValues={1}

--- a/client/src/pages/TopicPage/components/TopicAdittionalInformationCard.tsx
+++ b/client/src/pages/TopicPage/components/TopicAdittionalInformationCard.tsx
@@ -66,13 +66,13 @@ const TopicAdittionalInformationCard = ({ topic }: ITopicAdittionalInformationCa
         <Divider />
         <TopicAdittionalInformationSection
           icon={<Users size={iconSize} />}
-          title='Supervisors'
+          title='Examiners'
           content={<AvatarUserList users={topic.supervisors} />}
         />
         <Divider />
         <TopicAdittionalInformationSection
           icon={<Users size={iconSize} />}
-          title='Advisors'
+          title='Supervisors'
           content={<AvatarUserList users={topic.advisors} />}
         />
       </Stack>

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -59,14 +59,16 @@ And execute all files that you need.
 
 #### Example Users and Roles
 
-| Username       | First Name | Last Name | Email                    | Role       |
-|----------------|------------|-----------|--------------------------|------------|
-| sam_fischer    | Sam        | Fischer   | sam_fischer@gmail.com    | supervisor |
-| jane_doe       | Jane       | Doe       | jane_doe@gmail.com       | supervisor |
-| joey_read      | Joey       | Read      | joey_read@gmail.com      | advisor    |
-| barney_young   | Barney     | Young     | barney_young@gmail.com   | advisor    |
-| chloe_mitchell | Chloe      | Mitchell  | chloe_mitchell@gmail.com | student    |
-| kelly_wilkins  | Kelly      | Wilkins   | kelly_wilkins@gmail.com  | student    |
+> **Note on Role Terminology:** The backend/Keycloak uses `supervisor` and `advisor` roles internally. In the UI, these are displayed as "Examiner" and "Supervisor" respectively to align with CIT terminology.
+
+| Username       | First Name | Last Name | Email                    | Role (Backend) | UI Label   |
+|----------------|------------|-----------|--------------------------|----------------|------------|
+| sam_fischer    | Sam        | Fischer   | sam_fischer@gmail.com    | supervisor     | Examiner   |
+| jane_doe       | Jane       | Doe       | jane_doe@gmail.com       | supervisor     | Examiner   |
+| joey_read      | Joey       | Read      | joey_read@gmail.com      | advisor        | Supervisor |
+| barney_young   | Barney     | Young     | barney_young@gmail.com   | advisor        | Supervisor |
+| chloe_mitchell | Chloe      | Mitchell  | chloe_mitchell@gmail.com | student        | Student    |
+| kelly_wilkins  | Kelly      | Wilkins   | kelly_wilkins@gmail.com  | student        | Student    |
 
 ## Postfix
 

--- a/docs/MAILS.md
+++ b/docs/MAILS.md
@@ -3,6 +3,8 @@
 Mails can be customized in the email_templates table in the database or via API calls.
 If no research group specific template is found, the default template will be used.
 
+> **Note on Role Terminology:** The backend uses `supervisor` and `advisor` roles internally. In the UI, these are displayed as "Examiner" and "Supervisor" respectively to align with CIT terminology.
+
 ## Templates
 
 | Template Case                                                                                                                                  | TO                             | CC                    | BCC                   | Description                                                                    |


### PR DESCRIPTION
## Summary

This PR updates the display labels for roles in the UI to align with CIT terminology:

- **`supervisor` role** → now displayed as **"Examiner"** in the UI
- **`advisor` role** → now displayed as **"Supervisor"** in the UI

This is a **UI-only change**. The server code, database schema, API field names, and Keycloak roles remain unchanged.

## Changes

### UI Components (11 files)

| File | Changes |
|------|---------|
| `ThesesTable.tsx` | Column titles: "Supervisor" → "Examiner", "Advisor(s)" → "Supervisor(s)" |
| `ThesisData.tsx` | Labels: "Supervisor" → "Examiner", "Advisor" → "Supervisor" (pluralized) |
| `TopicData.tsx` | Labels: "Supervisor" → "Examiner", "Advisor" → "Supervisor" (pluralized) |
| `TopicsTable.tsx` | Column titles: "Supervisor" → "Examiner", "Advisor(s)" → "Supervisor(s)" |
| `CreateThesisModal.tsx` | Form labels: "Advisor(s)" → "Supervisor(s)", "Supervisor" → "Examiner" |
| `PublishedTheses.tsx` | Column title: "Advisor(s)" → "Supervisor(s)" |
| `ReplaceTopicModal.tsx` | Form labels: "Supervisor" → "Examiner", "Advisor(s)" → "Supervisor(s)" |
| `CollapsibleTopicElement.tsx` | Labels: "Supervisor" → "Examiner", "Advisor" → "Supervisor" (pluralized) |
| `ResearchGroupMembers.tsx` | Select options: "Advisor" → "Supervisor", "Supervisor" → "Examiner" |
| `ThesisConfigSection.tsx` | Form labels: "Advisor(s)" → "Supervisor(s)", "Supervisor" → "Examiner" |
| `TopicAdittionalInformationCard.tsx` | Section titles: "Supervisors" → "Examiners", "Advisors" → "Supervisors" |

### Documentation (2 files)

| File | Changes |
|------|---------|
| `DEVELOPMENT.md` | Added note about role terminology mapping and UI Label column to example users table |
| `MAILS.md` | Added note explaining the server vs UI role terminology |

## Technical Details

- **No server changes required** - API field names (`supervisorIds`, `advisorIds`) remain the same
- **No database migration needed** - schema is unchanged
- **No Keycloak changes needed** - role names remain `supervisor` and `advisor`
- Build compiles successfully
- Prettier formatting passes

## Test Plan

- [ ] Browse topics page - verify "Examiner" and "Supervisor" labels appear correctly
- [ ] Create thesis modal - verify form labels show "Examiner" and "Supervisor(s)"
- [ ] Thesis config section - verify labels in thesis editing
- [ ] Research group members page - verify role select dropdown shows "Examiner" and "Supervisor"
- [ ] Landing page / Published theses - verify column headers
- [ ] Topic details page - verify role labels in additional information card

🤖 Generated with [Claude Code](https://claude.com/claude-code)