### PR TITLE
`Development`: Fix server test for ThesisAnonymizationService

### DIFF
--- a/server/src/test/java/de/tum/cit/aet/thesis/service/ThesisAnonymizationServiceTest.java
+++ b/server/src/test/java/de/tum/cit/aet/thesis/service/ThesisAnonymizationServiceTest.java
@@ -377,8 +377,8 @@ class ThesisAnonymizationServiceTest extends BaseIntegrationTest {
 		void notifiesForThesisApproachingExpiry() throws Exception {
 			createTestEmailTemplate("THESIS_ANONYMIZATION_REMINDER");
 
-			// Thesis finished ~6.3 years ago → retention expiry at least 5 years ago
-			// which is in the past and thus within the 30-day notification horizon.
+			// Thesis finished ~6.3 years ago → retention expiry is safely in the past
+			// and thus within the 30-day notification horizon.
 			// This thesis should definitely be notified.
 			Instant createdAt = Instant.now().minus(2300, ChronoUnit.DAYS);
 			Instant endDate = Instant.now().minus(2250, ChronoUnit.DAYS);

--- a/server/src/test/java/de/tum/cit/aet/thesis/service/ThesisAnonymizationServiceTest.java
+++ b/server/src/test/java/de/tum/cit/aet/thesis/service/ThesisAnonymizationServiceTest.java
@@ -377,11 +377,11 @@ class ThesisAnonymizationServiceTest extends BaseIntegrationTest {
 		void notifiesForThesisApproachingExpiry() throws Exception {
 			createTestEmailTemplate("THESIS_ANONYMIZATION_REMINDER");
 
-			// Thesis finished ~5.2 years ago (endDate in 2020) → retention expiry = Dec 31, 2025
+			// Thesis finished ~6.3 years ago → retention expiry at least 5 years ago
 			// which is in the past and thus within the 30-day notification horizon.
 			// This thesis should definitely be notified.
-			Instant createdAt = Instant.now().minus(1950, ChronoUnit.DAYS);
-			Instant endDate = Instant.now().minus(1900, ChronoUnit.DAYS);
+			Instant createdAt = Instant.now().minus(2300, ChronoUnit.DAYS);
+			Instant endDate = Instant.now().minus(2250, ChronoUnit.DAYS);
 			Thesis thesis = createTestThesisWithChildren(ThesisState.FINISHED, createdAt, endDate);
 
 			thesisAnonymizationService.sendAnonymizationNotifications();


### PR DESCRIPTION
- The `notifiesForThesisApproachingExpiry` test used a 1900-day offset (~5.2 years) for the end date. Until recently, this resulted in an end date in late 2020. Since theses are anonymized at the end of each year after 5 years, the retention expiry (end of that year + 5 years) was Dec 31, 2025, which is why the test previously passed on `develop`.
- As time progressed, the computed end date shifted into early 2021, moving the retention expiry to Dec 31, 2026. This caused the test to fail.
- Increased the offset to 2250 days (~6.3 years) to ensure the retention expiry is always safely in the past, preventing the test from becoming flaky as time advances.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Adjusted a test for anonymization notification timing by moving historical timestamps further back and updating related comments; test behavior and assertions remain unchanged (still verifies anonymization notification is set).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->