### PR TITLE
disabled test notifiesForThesisApproachingExpiry

### DIFF
--- a/server/src/test/java/de/tum/cit/aet/thesis/service/ThesisAnonymizationServiceTest.java
+++ b/server/src/test/java/de/tum/cit/aet/thesis/service/ThesisAnonymizationServiceTest.java
@@ -374,6 +374,7 @@ class ThesisAnonymizationServiceTest extends BaseIntegrationTest {
 	class SendAnonymizationNotifications {
 
 		@Test
+		@Disabled("Flaky: date arithmetic is timezone/calendar-sensitive, needs refactor with mocked clock")
 		void notifiesForThesisApproachingExpiry() throws Exception {
 			createTestEmailTemplate("THESIS_ANONYMIZATION_REMINDER");
 


### PR DESCRIPTION
The test notifiesForThesisApproachingExpiry in ThesisAnonymizationServiceTest was failing intermittently due to date arithmetic that is sensitive to the current calendar date and timezone. The retention expiry window computed by RetentionUtils (end of calendar year + 5 years) makes it difficult to construct a test thesis whose expiry reliably falls within the 30-day notification horizon without a mocked clock.
The test is disabled pending a proper refactor that injects a Clock bean into ThesisAnonymizationService, allowing tests to fix "now" to a known value and compute dates deterministically.
Changes

Added @Disabled to notifiesForThesisApproachingExpiry() in ThesisAnonymizationServiceTest

No production code is affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Disabled a test case experiencing reliability issues that requires refactoring with improved testing mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->