### PR TITLE
Slim down presentation/interview ICS files and improve event title

### DIFF
--- a/client/e2e/calendar-subscription.spec.ts
+++ b/client/e2e/calendar-subscription.spec.ts
@@ -1,0 +1,87 @@
+import { test, expect } from '@playwright/test'
+
+const API_BASE = process.env.SERVER_URL ?? 'http://localhost:8180'
+
+// Seed data: DSA research group has thesis 3 (MASTER) with a scheduled PUBLIC final
+// presentation. The student is "Student3 User". The thesis title is
+// "Online Anomaly Detection in IoT Sensor Streams".
+const RESEARCH_GROUP_ABBREVIATION = 'DSA'
+const EXPECTED_THESIS_TITLE = 'Online Anomaly Detection in IoT Sensor Streams'
+
+test.describe('Public presentation calendar subscription', () => {
+  test.use({ storageState: { cookies: [], origins: [] } })
+
+  test('subscription feed is unauthenticated and returns text/calendar', async ({ request }) => {
+    const response = await request.get(
+      `${API_BASE}/api/v2/calendar/presentations/${RESEARCH_GROUP_ABBREVIATION}`,
+    )
+
+    expect(response.status()).toBe(200)
+    expect(response.headers()['content-type']).toContain('text/calendar')
+
+    const body = await response.text()
+    expect(body).toMatch(/^BEGIN:VCALENDAR/m)
+    expect(body).toMatch(/END:VCALENDAR\s*$/)
+    expect(body).toContain('METHOD:PUBLISH')
+  })
+
+  test('subscription feed contains no ATTENDEE lines (privacy guarantee)', async ({ request }) => {
+    const response = await request.get(
+      `${API_BASE}/api/v2/calendar/presentations/${RESEARCH_GROUP_ABBREVIATION}`,
+    )
+    expect(response.ok()).toBeTruthy()
+
+    const body = await response.text()
+
+    // The feed must contain at least one event from seed data so we know we're
+    // actually testing a populated calendar, not an empty one.
+    expect(body).toContain('BEGIN:VEVENT')
+    expect(body).toContain(EXPECTED_THESIS_TITLE)
+
+    // Privacy contract: the unauthenticated feed must not list any participant
+    // emails. ical4j may fold long lines, so check the unfolded body. We
+    // intentionally allow the ORGANIZER mailto (the system's own application
+    // address, needed so calendar clients know where replies should go) but
+    // forbid ATTENDEE lines, which is where user emails would surface.
+    const unfolded = body.replace(/\r?\n[ \t]/g, '')
+    expect(unfolded).not.toMatch(/^ATTENDEE[:;]/m)
+    expect(unfolded).not.toMatch(/^X-ATTENDEE/im)
+
+    // Sanity check: every mailto: occurrence must belong to an ORGANIZER line.
+    const mailtoLines = unfolded.split(/\r?\n/).filter((line) => /mailto:/i.test(line))
+    for (const line of mailtoLines) {
+      expect(line).toMatch(/^ORGANIZER[:;]/)
+    }
+  })
+
+  test('subscription feed uses the short-type + student-name title format', async ({ request }) => {
+    const response = await request.get(
+      `${API_BASE}/api/v2/calendar/presentations/${RESEARCH_GROUP_ABBREVIATION}`,
+    )
+    expect(response.ok()).toBeTruthy()
+
+    const body = await response.text()
+    const unfolded = body.replace(/\r?\n[ \t]/g, '')
+
+    // Thesis 3 is a MASTER thesis with student "Student3 User".
+    // Expected SUMMARY: "MA Presentation Student3 User: Online Anomaly Detection in IoT Sensor Streams"
+    const summaryMatch = unfolded.match(
+      new RegExp(`SUMMARY:.*${EXPECTED_THESIS_TITLE.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`),
+    )
+    expect(summaryMatch, 'Expected a SUMMARY line containing the thesis title').not.toBeNull()
+
+    const summary = summaryMatch![0]
+    expect(summary).toContain('MA Presentation')
+    expect(summary).toContain('Student3 User')
+    expect(summary).toMatch(/MA Presentation Student3 User:/)
+    // No legacy quoted-title format.
+    expect(summary).not.toContain('Thesis Presentation "')
+  })
+
+  test('unknown abbreviation returns 404', async ({ request }) => {
+    const response = await request.get(
+      `${API_BASE}/api/v2/calendar/presentations/this-group-does-not-exist`,
+    )
+    expect(response.status()).toBe(404)
+  })
+})

--- a/server/src/main/java/de/tum/cit/aet/thesis/service/InterviewProcessService.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/service/InterviewProcessService.java
@@ -669,8 +669,8 @@ public class InterviewProcessService {
 				slot.getStartDate(),
 				slot.getEndDate(),
 				this.applicationMail,
-				slot.getInterviewProcess().getTopic().getRoles().stream().map(role -> role.getUser().getEmail()).toList(),
-				new ArrayList<>()
+				List.of(),
+				List.of()
 		);
 	}
 

--- a/server/src/main/java/de/tum/cit/aet/thesis/service/ThesisPresentationService.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/service/ThesisPresentationService.java
@@ -170,7 +170,7 @@ public class ThesisPresentationService {
 		);
 
 		for (ThesisPresentation presentation : presentations) {
-			calendar.add(calendarService.createVEvent(presentation.getId().toString(), createPresentationCalendarEventWithoutAccessCheck(presentation)));
+			calendar.add(calendarService.createVEvent(presentation.getId().toString(), createPresentationCalendarEventWithoutAccessCheck(presentation, false)));
 		}
 
 		return calendar;
@@ -394,18 +394,22 @@ public class ThesisPresentationService {
 	private CalendarService.CalendarEvent createPresentationCalendarEvent(ThesisPresentation presentation) {
 		Thesis thesis = presentation.getThesis();
 		currentUserProvider().assertCanAccessResearchGroup(thesis.getResearchGroup());
-		return createPresentationCalendarEventWithoutAccessCheck(presentation);
+		return createPresentationCalendarEventWithoutAccessCheck(presentation, true);
 	}
 
-	private CalendarService.CalendarEvent createPresentationCalendarEventWithoutAccessCheck(ThesisPresentation presentation) {
+	private CalendarService.CalendarEvent createPresentationCalendarEventWithoutAccessCheck(ThesisPresentation presentation, boolean includeRoleAttendees) {
 		Thesis thesis = presentation.getThesis();
 		String location = presentation.getLocation();
 		String streamUrl = presentation.getStreamUrl();
 
 		int groupSettingsDuration = researchGroupSettingsService.getPresentationDurationInMinutes(thesis.getResearchGroup().getId());
 
+		List<InternetAddress> requiredAttendees = includeRoleAttendees
+				? thesis.getRoles().stream().map(role -> role.getUser().getEmail()).toList()
+				: List.of();
+
 		return new CalendarService.CalendarEvent(
-				"Thesis Presentation \"" + thesis.getTitle() + "\"",
+				buildPresentationTitle(thesis),
 				location == null || location.isBlank() ? streamUrl : location,
 				"Title: " + thesis.getTitle() + "\n" +
 						(streamUrl != null && !streamUrl.isBlank() ? "Stream URL: " + streamUrl + "\n" : "") + "\n" +
@@ -415,8 +419,37 @@ public class ThesisPresentationService {
 				presentation.getScheduledAt(),
 				presentation.getScheduledAt().plus(groupSettingsDuration, ChronoUnit.MINUTES),
 				this.applicationMail,
-				thesis.getRoles().stream().map(role -> role.getUser().getEmail()).toList(),
-				presentation.getInvites().stream().map(ThesisPresentationInvite::getEmail).toList()
+				requiredAttendees,
+				List.of()
 		);
+	}
+
+	private String buildPresentationTitle(Thesis thesis) {
+		String prefix = shortThesisType(thesis.getType()) + " Presentation";
+		String students = thesis.getStudents().stream()
+				.map(user -> {
+					String first = user.getFirstName() == null ? "" : user.getFirstName().trim();
+					String last = user.getLastName() == null ? "" : user.getLastName().trim();
+					return (first + " " + last).trim();
+				})
+				.filter(name -> !name.isEmpty())
+				.reduce((a, b) -> a + " & " + b)
+				.orElse("");
+
+		String header = students.isEmpty() ? prefix : prefix + " " + students;
+		return header + ": " + thesis.getTitle();
+	}
+
+	private static String shortThesisType(String type) {
+		if (type == null) {
+			return "Thesis";
+		}
+		return switch (type) {
+			case "BACHELOR" -> "BA";
+			case "MASTER" -> "MA";
+			case "INTERDISCIPLINARY_PROJECT" -> "IDP";
+			case "GUIDED_RESEARCH" -> "GR";
+			default -> type;
+		};
 	}
 }

--- a/server/src/main/java/de/tum/cit/aet/thesis/service/ThesisPresentationService.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/service/ThesisPresentationService.java
@@ -399,7 +399,12 @@ public class ThesisPresentationService {
 	private CalendarService.CalendarEvent buildInviteCalendarEvent(ThesisPresentation presentation) {
 		Thesis thesis = presentation.getThesis();
 		currentUserProvider().assertCanAccessResearchGroup(thesis.getResearchGroup());
-		List<InternetAddress> roleAttendees = thesis.getRoles().stream().map(role -> role.getUser().getEmail()).toList();
+		List<InternetAddress> roleAttendees = thesis.getRoles().stream()
+				.filter(role -> switch (role.getId().getRole()) {
+					case STUDENT, SUPERVISOR, EXAMINER -> true;
+				})
+				.map(role -> role.getUser().getEmail())
+				.toList();
 		return buildPresentationCalendarEvent(presentation, roleAttendees);
 	}
 

--- a/server/src/main/java/de/tum/cit/aet/thesis/service/ThesisPresentationService.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/service/ThesisPresentationService.java
@@ -454,7 +454,7 @@ public class ThesisPresentationService {
 	}
 
 	static String shortThesisType(String type) {
-		if (type == null) {
+		if (type == null || type.isBlank()) {
 			return "Thesis";
 		}
 		return switch (type) {

--- a/server/src/main/java/de/tum/cit/aet/thesis/service/ThesisPresentationService.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/service/ThesisPresentationService.java
@@ -170,7 +170,7 @@ public class ThesisPresentationService {
 		);
 
 		for (ThesisPresentation presentation : presentations) {
-			calendar.add(calendarService.createVEvent(presentation.getId().toString(), createPresentationCalendarEventWithoutAccessCheck(presentation, false)));
+			calendar.add(calendarService.createVEvent(presentation.getId().toString(), buildSubscriptionCalendarEvent(presentation)));
 		}
 
 		return calendar;
@@ -187,7 +187,7 @@ public class ThesisPresentationService {
 
 		calendar.add(ImmutableMethod.REQUEST);
 
-		calendar.add(calendarService.createVEvent(presentation.getId().toString(), createPresentationCalendarEvent(presentation)));
+		calendar.add(calendarService.createVEvent(presentation.getId().toString(), buildInviteCalendarEvent(presentation)));
 
 		return calendar;
 	}
@@ -391,22 +391,33 @@ public class ThesisPresentationService {
 		return presentation;
 	}
 
-	private CalendarService.CalendarEvent createPresentationCalendarEvent(ThesisPresentation presentation) {
+	/**
+	 * Builds the calendar event used for the personal email invite. Verifies the caller can
+	 * access the thesis and includes the thesis role members (student, supervisor, examiner)
+	 * as required attendees so the recipient's mail client can show the named participants.
+	 */
+	private CalendarService.CalendarEvent buildInviteCalendarEvent(ThesisPresentation presentation) {
 		Thesis thesis = presentation.getThesis();
 		currentUserProvider().assertCanAccessResearchGroup(thesis.getResearchGroup());
-		return createPresentationCalendarEventWithoutAccessCheck(presentation, true);
+		List<InternetAddress> roleAttendees = thesis.getRoles().stream().map(role -> role.getUser().getEmail()).toList();
+		return buildPresentationCalendarEvent(presentation, roleAttendees);
 	}
 
-	private CalendarService.CalendarEvent createPresentationCalendarEventWithoutAccessCheck(ThesisPresentation presentation, boolean includeRoleAttendees) {
+	/**
+	 * Builds the calendar event used for the public subscription feed. Skips the access check
+	 * (the feed is intentionally public) and emits no ATTENDEE entries — subscribers already
+	 * have the event, and exposing attendee emails on an unauthenticated feed would leak addresses.
+	 */
+	private CalendarService.CalendarEvent buildSubscriptionCalendarEvent(ThesisPresentation presentation) {
+		return buildPresentationCalendarEvent(presentation, List.of());
+	}
+
+	private CalendarService.CalendarEvent buildPresentationCalendarEvent(ThesisPresentation presentation, List<InternetAddress> requiredAttendees) {
 		Thesis thesis = presentation.getThesis();
 		String location = presentation.getLocation();
 		String streamUrl = presentation.getStreamUrl();
 
 		int groupSettingsDuration = researchGroupSettingsService.getPresentationDurationInMinutes(thesis.getResearchGroup().getId());
-
-		List<InternetAddress> requiredAttendees = includeRoleAttendees
-				? thesis.getRoles().stream().map(role -> role.getUser().getEmail()).toList()
-				: List.of();
 
 		return new CalendarService.CalendarEvent(
 				buildPresentationTitle(thesis),
@@ -424,7 +435,7 @@ public class ThesisPresentationService {
 		);
 	}
 
-	private String buildPresentationTitle(Thesis thesis) {
+	static String buildPresentationTitle(Thesis thesis) {
 		String prefix = shortThesisType(thesis.getType()) + " Presentation";
 		String students = thesis.getStudents().stream()
 				.map(user -> {
@@ -436,11 +447,13 @@ public class ThesisPresentationService {
 				.reduce((a, b) -> a + " & " + b)
 				.orElse("");
 
-		String header = students.isEmpty() ? prefix : prefix + " " + students;
-		return header + ": " + thesis.getTitle();
+		if (students.isEmpty()) {
+			return prefix + " – " + thesis.getTitle();
+		}
+		return prefix + " " + students + ": " + thesis.getTitle();
 	}
 
-	private static String shortThesisType(String type) {
+	static String shortThesisType(String type) {
 		if (type == null) {
 			return "Thesis";
 		}

--- a/server/src/test/java/de/tum/cit/aet/thesis/service/InterviewProcessServiceTest.java
+++ b/server/src/test/java/de/tum/cit/aet/thesis/service/InterviewProcessServiceTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
@@ -750,5 +751,40 @@ class InterviewProcessServiceTest {
 		slot.setStartDate(start);
 		slot.setEndDate(end);
 		return slot;
+	}
+
+	@Test
+	void getInterviewCalendarForUser_EmitsEventsWithoutAttendees() {
+		UUID userId = UUID.randomUUID();
+
+		Topic topic = new Topic();
+		topic.setTitle("Interview Topic");
+		topic.setRoles(new ArrayList<>());
+
+		InterviewProcess process = new InterviewProcess();
+		process.setTopic(topic);
+
+		InterviewSlot slot = createSlot(process,
+				Instant.now().plusSeconds(3600),
+				Instant.now().plusSeconds(7200));
+
+		when(interviewProcessRepository.findAllMyInterviewSlots(userId))
+				.thenReturn(List.of(slot));
+		when(calendarService.createEmptyCalendar(anyString()))
+				.thenReturn(new net.fortuna.ical4j.model.Calendar());
+		when(calendarService.createVEvent(anyString(), any()))
+				.thenReturn(new net.fortuna.ical4j.model.component.VEvent());
+
+		interviewProcessService.getInterviewCalendarForUser(userId);
+
+		ArgumentCaptor<CalendarService.CalendarEvent> captor =
+				ArgumentCaptor.forClass(CalendarService.CalendarEvent.class);
+		verify(calendarService).createVEvent(anyString(), captor.capture());
+
+		CalendarService.CalendarEvent event = captor.getValue();
+		assertTrue(event.requiredAttendees().isEmpty(),
+				"Interview subscription feed must not leak role emails as required attendees");
+		assertTrue(event.optionalAttendees().isEmpty(),
+				"Interview subscription feed must not include optional attendees");
 	}
 }

--- a/server/src/test/java/de/tum/cit/aet/thesis/service/ThesisPresentationServiceTest.java
+++ b/server/src/test/java/de/tum/cit/aet/thesis/service/ThesisPresentationServiceTest.java
@@ -12,8 +12,10 @@ import de.tum.cit.aet.thesis.constants.ThesisRoleName;
 import de.tum.cit.aet.thesis.entity.ResearchGroup;
 import de.tum.cit.aet.thesis.entity.Thesis;
 import de.tum.cit.aet.thesis.entity.ThesisPresentation;
+import de.tum.cit.aet.thesis.entity.ThesisPresentationInvite;
 import de.tum.cit.aet.thesis.entity.ThesisRole;
 import de.tum.cit.aet.thesis.entity.User;
+import de.tum.cit.aet.thesis.entity.key.ThesisPresentationInviteId;
 import de.tum.cit.aet.thesis.entity.key.ThesisRoleId;
 import de.tum.cit.aet.thesis.exception.request.AccessDeniedException;
 import de.tum.cit.aet.thesis.exception.request.ResourceInvalidParametersException;
@@ -298,8 +300,11 @@ class ThesisPresentationServiceTest {
 		User student = addThesisRole(testThesis, "alice@example.com", ThesisRoleName.STUDENT);
 		User supervisor = addThesisRole(testThesis, "bob@example.com", ThesisRoleName.SUPERVISOR);
 
-		// Simulate a large BCC invitee list — must NOT appear in the ICS.
-		testPresentation.setInvites(List.of());
+		// Simulate BCC invitees that must NOT leak into the attached ICS file.
+		testPresentation.setInvites(List.of(
+				invite(testPresentation, "invitee1@example.com"),
+				invite(testPresentation, "invitee2@example.com")
+		));
 
 		when(currentUserProviderProvider.getObject()).thenReturn(currentUserProvider);
 		when(calendarService.createVEvent(anyString(), any())).thenReturn(new VEvent());
@@ -321,6 +326,17 @@ class ThesisPresentationServiceTest {
 				"Email invite ICS should expose only thesis role members as attendees");
 		assertTrue(event.optionalAttendees().isEmpty(),
 				"Email invite ICS must never carry the BCC invitee list as optional attendees");
+	}
+
+	private static ThesisPresentationInvite invite(ThesisPresentation presentation, String email) {
+		ThesisPresentationInvite invite = new ThesisPresentationInvite();
+		ThesisPresentationInviteId id = new ThesisPresentationInviteId();
+		id.setPresentationId(presentation.getId());
+		id.setEmail(email);
+		invite.setId(id);
+		invite.setPresentation(presentation);
+		invite.setInvitedAt(Instant.now());
+		return invite;
 	}
 
 	private static User addThesisRole(Thesis thesis, String email, ThesisRoleName roleName) {

--- a/server/src/test/java/de/tum/cit/aet/thesis/service/ThesisPresentationServiceTest.java
+++ b/server/src/test/java/de/tum/cit/aet/thesis/service/ThesisPresentationServiceTest.java
@@ -8,10 +8,13 @@ import static org.mockito.Mockito.when;
 import de.tum.cit.aet.thesis.constants.ThesisPresentationState;
 import de.tum.cit.aet.thesis.constants.ThesisPresentationType;
 import de.tum.cit.aet.thesis.constants.ThesisPresentationVisibility;
+import de.tum.cit.aet.thesis.constants.ThesisRoleName;
 import de.tum.cit.aet.thesis.entity.ResearchGroup;
 import de.tum.cit.aet.thesis.entity.Thesis;
 import de.tum.cit.aet.thesis.entity.ThesisPresentation;
+import de.tum.cit.aet.thesis.entity.ThesisRole;
 import de.tum.cit.aet.thesis.entity.User;
+import de.tum.cit.aet.thesis.entity.key.ThesisRoleId;
 import de.tum.cit.aet.thesis.exception.request.AccessDeniedException;
 import de.tum.cit.aet.thesis.exception.request.ResourceInvalidParametersException;
 import de.tum.cit.aet.thesis.exception.request.ResourceNotFoundException;
@@ -26,6 +29,7 @@ import net.fortuna.ical4j.model.component.VEvent;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.ObjectProvider;
@@ -264,5 +268,80 @@ class ThesisPresentationServiceTest {
 		assertEquals(1, result.getComponents().size());
 		verify(calendarService).createVEvent(anyString(), any());
 		verify(thesisPresentationRepository).findAllPresentations(isNull(), anySet());
+	}
+
+	@Test
+	void getPresentationCalendar_EmitsEventsWithoutAttendees() {
+		addThesisRole(testThesis, "alice@example.com", ThesisRoleName.STUDENT);
+		testPresentation.setInvites(List.of());
+
+		when(thesisPresentationRepository.findAllPresentations(isNull(), anySet()))
+				.thenReturn(List.of(testPresentation));
+		when(calendarService.createVEvent(anyString(), any())).thenReturn(new VEvent());
+		when(calendarService.createEmptyCalendar(anyString())).thenReturn(new Calendar());
+
+		presentationService.getPresentationCalendar(null);
+
+		ArgumentCaptor<CalendarService.CalendarEvent> captor =
+				ArgumentCaptor.forClass(CalendarService.CalendarEvent.class);
+		verify(calendarService).createVEvent(anyString(), captor.capture());
+
+		CalendarService.CalendarEvent event = captor.getValue();
+		assertTrue(event.requiredAttendees().isEmpty(),
+				"Public subscription feed must not include required attendees");
+		assertTrue(event.optionalAttendees().isEmpty(),
+				"Public subscription feed must not include optional attendees");
+	}
+
+	@Test
+	void getPresentationInvite_IncludesRoleAttendeesAndOmitsInviteeBccList() {
+		User student = addThesisRole(testThesis, "alice@example.com", ThesisRoleName.STUDENT);
+		User supervisor = addThesisRole(testThesis, "bob@example.com", ThesisRoleName.SUPERVISOR);
+
+		// Simulate a large BCC invitee list — must NOT appear in the ICS.
+		testPresentation.setInvites(List.of());
+
+		when(currentUserProviderProvider.getObject()).thenReturn(currentUserProvider);
+		when(calendarService.createVEvent(anyString(), any())).thenReturn(new VEvent());
+		when(calendarService.createEmptyCalendar(anyString())).thenReturn(new Calendar());
+
+		presentationService.getPresentationInvite(testPresentation);
+
+		ArgumentCaptor<CalendarService.CalendarEvent> captor =
+				ArgumentCaptor.forClass(CalendarService.CalendarEvent.class);
+		verify(calendarService).createVEvent(anyString(), captor.capture());
+
+		CalendarService.CalendarEvent event = captor.getValue();
+		List<String> requiredEmails = event.requiredAttendees().stream()
+				.map(InternetAddress::getAddress)
+				.toList();
+		assertEquals(
+				List.of(student.getEmail().getAddress(), supervisor.getEmail().getAddress()),
+				requiredEmails,
+				"Email invite ICS should expose only thesis role members as attendees");
+		assertTrue(event.optionalAttendees().isEmpty(),
+				"Email invite ICS must never carry the BCC invitee list as optional attendees");
+	}
+
+	private static User addThesisRole(Thesis thesis, String email, ThesisRoleName roleName) {
+		User user = new User();
+		user.setId(UUID.randomUUID());
+		user.setFirstName("First");
+		user.setLastName("Last");
+		user.setEmail(email);
+
+		ThesisRole role = new ThesisRole();
+		ThesisRoleId roleId = new ThesisRoleId();
+		roleId.setRole(roleName);
+		role.setId(roleId);
+		role.setThesis(thesis);
+		role.setUser(user);
+
+		List<ThesisRole> roles = new ArrayList<>(
+				thesis.getRoles() == null ? List.of() : thesis.getRoles());
+		roles.add(role);
+		thesis.setRoles(roles);
+
+		return user;
 	}
 }

--- a/server/src/test/java/de/tum/cit/aet/thesis/service/ThesisPresentationTitleTest.java
+++ b/server/src/test/java/de/tum/cit/aet/thesis/service/ThesisPresentationTitleTest.java
@@ -33,6 +33,12 @@ class ThesisPresentationTitleTest {
 	}
 
 	@Test
+	void shortThesisType_blankFallsBackToThesis() {
+		assertEquals("Thesis", ThesisPresentationService.shortThesisType(""));
+		assertEquals("Thesis", ThesisPresentationService.shortThesisType("   "));
+	}
+
+	@Test
 	void buildPresentationTitle_singleStudent() {
 		Thesis thesis = thesis("BACHELOR", "Enhancing Terminal Usability");
 		addStudent(thesis, "John", "Doe");

--- a/server/src/test/java/de/tum/cit/aet/thesis/service/ThesisPresentationTitleTest.java
+++ b/server/src/test/java/de/tum/cit/aet/thesis/service/ThesisPresentationTitleTest.java
@@ -1,0 +1,136 @@
+package de.tum.cit.aet.thesis.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import de.tum.cit.aet.thesis.constants.ThesisRoleName;
+import de.tum.cit.aet.thesis.entity.Thesis;
+import de.tum.cit.aet.thesis.entity.ThesisRole;
+import de.tum.cit.aet.thesis.entity.User;
+import de.tum.cit.aet.thesis.entity.key.ThesisRoleId;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+class ThesisPresentationTitleTest {
+
+	@Test
+	void shortThesisType_mapsKnownKeys() {
+		assertEquals("BA", ThesisPresentationService.shortThesisType("BACHELOR"));
+		assertEquals("MA", ThesisPresentationService.shortThesisType("MASTER"));
+		assertEquals("IDP", ThesisPresentationService.shortThesisType("INTERDISCIPLINARY_PROJECT"));
+		assertEquals("GR", ThesisPresentationService.shortThesisType("GUIDED_RESEARCH"));
+	}
+
+	@Test
+	void shortThesisType_unknownKeyFallsBackToRawValue() {
+		assertEquals("DOCTORATE", ThesisPresentationService.shortThesisType("DOCTORATE"));
+	}
+
+	@Test
+	void shortThesisType_nullFallsBackToThesis() {
+		assertEquals("Thesis", ThesisPresentationService.shortThesisType(null));
+	}
+
+	@Test
+	void buildPresentationTitle_singleStudent() {
+		Thesis thesis = thesis("BACHELOR", "Enhancing Terminal Usability");
+		addStudent(thesis, "John", "Doe");
+
+		assertEquals(
+				"BA Presentation John Doe: Enhancing Terminal Usability",
+				ThesisPresentationService.buildPresentationTitle(thesis)
+		);
+	}
+
+	@Test
+	void buildPresentationTitle_multipleStudentsJoinedWithAmpersand() {
+		Thesis thesis = thesis("MASTER", "Joint Thesis");
+		addStudent(thesis, "Alice", "Smith");
+		addStudent(thesis, "Bob", "Jones");
+
+		assertEquals(
+				"MA Presentation Alice Smith & Bob Jones: Joint Thesis",
+				ThesisPresentationService.buildPresentationTitle(thesis)
+		);
+	}
+
+	@Test
+	void buildPresentationTitle_noStudentsUsesDashSeparator() {
+		Thesis thesis = thesis("INTERDISCIPLINARY_PROJECT", "Unassigned Topic");
+
+		assertEquals(
+				"IDP Presentation – Unassigned Topic",
+				ThesisPresentationService.buildPresentationTitle(thesis)
+		);
+	}
+
+	@Test
+	void buildPresentationTitle_nullFirstNameDoesNotProduceNullLiteral() {
+		Thesis thesis = thesis("GUIDED_RESEARCH", "Research Topic");
+		addStudent(thesis, null, "Doe");
+
+		assertEquals(
+				"GR Presentation Doe: Research Topic",
+				ThesisPresentationService.buildPresentationTitle(thesis)
+		);
+	}
+
+	@Test
+	void buildPresentationTitle_nameContainingCommaIsPreservedInSummary() {
+		Thesis thesis = thesis("BACHELOR", "Some Title");
+		addStudent(thesis, "Maria", "García, Sr.");
+
+		assertEquals(
+				"BA Presentation Maria García, Sr.: Some Title",
+				ThesisPresentationService.buildPresentationTitle(thesis)
+		);
+	}
+
+	@Test
+	void buildPresentationTitle_unknownTypeFallsBackToRawKey() {
+		Thesis thesis = thesis("DOCTORATE", "Doctoral Topic");
+		addStudent(thesis, "Eve", "Williams");
+
+		assertEquals(
+				"DOCTORATE Presentation Eve Williams: Doctoral Topic",
+				ThesisPresentationService.buildPresentationTitle(thesis)
+		);
+	}
+
+	@Test
+	void buildPresentationTitle_nullTypeFallsBackToThesisPrefix() {
+		Thesis thesis = thesis(null, "Some Title");
+		addStudent(thesis, "Pat", "Lee");
+
+		assertEquals(
+				"Thesis Presentation Pat Lee: Some Title",
+				ThesisPresentationService.buildPresentationTitle(thesis)
+		);
+	}
+
+	private static Thesis thesis(String type, String title) {
+		Thesis thesis = new Thesis();
+		thesis.setType(type);
+		thesis.setTitle(title);
+		thesis.setRoles(new ArrayList<>());
+		return thesis;
+	}
+
+	private static void addStudent(Thesis thesis, String firstName, String lastName) {
+		User user = new User();
+		user.setFirstName(firstName);
+		user.setLastName(lastName);
+
+		ThesisRole role = new ThesisRole();
+		ThesisRoleId roleId = new ThesisRoleId();
+		roleId.setRole(ThesisRoleName.STUDENT);
+		role.setId(roleId);
+		role.setThesis(thesis);
+		role.setUser(user);
+
+		List<ThesisRole> roles = new ArrayList<>(thesis.getRoles());
+		roles.add(role);
+		thesis.setRoles(roles);
+	}
+}


### PR DESCRIPTION
## Summary

- **Privacy**: stop leaking invitee email addresses through generated `.ics` files.
- **Performance**: drastically shrink ICS payloads (we observed 85+ `ATTENDEE` entries per event) so mail and calendar clients render presentation invites and subscription feeds quickly.
- **Readability**: rework the event title so the student name and thesis type stay visible when calendar clients truncate.

## Changes

### Attendees in ICS files

`CalendarService.createVEvent` emits one `ATTENDEE;…:mailto:<email>` line per address. Two callers were over-sharing:

- `ThesisPresentationService.getPresentationCalendar` (the public `/v2/calendar/presentations/{abbreviation}` subscription feed) was including every thesis role member *and* every public invitee for every public presentation in the feed. This is unauthenticated, so any subscriber received the full invitee list of every event. After this change the subscription feed contains **no** `ATTENDEE` lines — subscribers already have the event in their calendar; they do not need a directory of co-invitees.
- `ThesisPresentationService.getPresentationInvite` (the `.ics` attached to scheduled/updated presentation emails) no longer adds `presentation.getInvites()` as optional attendees. The thesis roles (student, supervisor, examiner) remain as required attendees because they are the named participants the calendar event is *for*. The 85+ BCC invitees are treated as an audience and intentionally omitted from the attachment so their addresses are not leaked to every other recipient.
- `InterviewProcessService.createInterviewSlotCalendarEvent` (the `/v2/calendar/interviews/user/{userId}` subscription feed) was similarly leaking topic role emails to every subscriber. Attendees are now empty for this feed too.

Implementation: `createPresentationCalendarEventWithoutAccessCheck` gained a `boolean includeRoleAttendees` parameter so the email-invite path (`true`) and the subscription path (`false`) share the same builder without duplicating event construction.

### Event title

Old: `Thesis Presentation "Enhancing Terminal Usability in Modern IDEs Through AI-Assisted Interaction"` — in most calendar UIs only `Thesis Presentation "Enhanci…` is visible.

New: `BA Presentation John Doe: Enhancing Terminal Usability in Modern IDEs Through AI-Assisted Interaction` — the short thesis-type code (`BA` / `MA` / `IDP` / `GR`) and the student name appear before the long title, so they survive truncation. Multiple students are joined with ` & `; unknown `thesis.type` values fall back to the raw type string, and a `null` type falls back to `Thesis`.

The mapping covers the four default `thesis_types` keys configured in `client/src/config/global.ts`. Custom installations that override `THESIS_TYPES` with non-standard keys will see the raw key as a fallback, which is still better than the previous generic `Thesis Presentation` prefix.

## Test plan

- [x] `./gradlew compileJava` succeeds
- [x] `./gradlew test --tests ThesisPresentationServiceTest` passes (existing test mocks the calendar service, so it still passes — the test does not assert on event content)
- [x] `./gradlew spotlessApply` applied
- [ ] Manual: schedule a presentation with several BCC invitees and confirm the attached `event.ics` contains only organizer + thesis roles (no invitee addresses)
- [ ] Manual: open the public subscription feed (`/v2/calendar/presentations/{abbreviation}`) and confirm `ATTENDEE` lines are absent
- [ ] Manual: subscribe in Outlook/Apple Calendar and confirm presentation entries show `BA Presentation <name>: <title>` and load noticeably faster than before
- [ ] Manual: open the interview subscription feed and confirm no `ATTENDEE` lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified calendar-event creation for interviews and presentations; attendee handling clarified and presentation titles now use a short thesis-type prefix plus optional student names.
  * Public presentation calendar feeds emit events without attendee email entries to avoid leaking role emails.

* **Tests**
  * Added unit and end-to-end tests validating title formatting, attendee behavior, and public-feed privacy (no attendee entries).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ls1intum/thesis-management/pull/1025)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->