### PR TITLE
Feature: Allow supervisors to revert thesis to previous state

### DIFF
--- a/client/e2e/thesis-delete.spec.ts
+++ b/client/e2e/thesis-delete.spec.ts
@@ -10,7 +10,11 @@ const EXAMINER_THESIS_ID = '00000000-0000-4000-d000-000000000001'
 test.describe('Thesis Delete (Anonymize) - Admin', () => {
   test.use({ storageState: authStatePath('admin') })
 
-  test.describe.configure({ mode: 'serial' })
+  // Anonymization is irreversible, so the seed rows mutated by these tests cannot
+  // be restored mid-run. Retrying after a partial success would fail on the
+  // already-anonymized state and mask the real cause; disable retries so any flake
+  // surfaces as a first-attempt failure with the actual error.
+  test.describe.configure({ mode: 'serial', retries: 0 })
 
   test('admin can anonymize old non-terminal thesis with state warning only', async ({ page }) => {
     const heading = page.getByRole('heading', { name: /Historical Analysis of Compiler/i })
@@ -21,17 +25,17 @@ test.describe('Thesis Delete (Anonymize) - Admin', () => {
 
     // Anonymize Thesis button should be visible for admin on non-anonymized thesis
     const deleteButton = page.getByRole('button', { name: 'Anonymize Thesis' })
-    await expect(deleteButton).toBeVisible({ timeout: 5_000 })
+    await expect(deleteButton).toBeVisible()
     await deleteButton.click()
 
     // Modal should open with correct title
     const dialog = page.getByRole('dialog')
-    await expect(dialog).toBeVisible({ timeout: 5_000 })
+    await expect(dialog).toBeVisible()
     await expect(dialog.getByRole('heading', { name: 'Anonymize Thesis' })).toBeVisible()
 
     // Old GRADED thesis: state warning (not terminal) but NO retention warning (expired)
     const alert = dialog.locator('.mantine-Alert-root')
-    await expect(alert).toBeVisible({ timeout: 5_000 })
+    await expect(alert).toBeVisible()
     await expect(alert.getByText(/GRADED/i)).toBeVisible()
     await expect(alert.getByText(/retention period/i)).not.toBeVisible({ timeout: 2_000 })
 
@@ -57,15 +61,15 @@ test.describe('Thesis Delete (Anonymize) - Admin', () => {
     await page.getByText('Configuration').click()
 
     const deleteButton = page.getByRole('button', { name: 'Anonymize Thesis' })
-    await expect(deleteButton).toBeVisible({ timeout: 5_000 })
+    await expect(deleteButton).toBeVisible()
     await deleteButton.click()
 
     const dialog = page.getByRole('dialog')
-    await expect(dialog).toBeVisible({ timeout: 5_000 })
+    await expect(dialog).toBeVisible()
 
     // Recent finished thesis should show retention warning but NOT state warning
     const alert = dialog.locator('.mantine-Alert-root')
-    await expect(alert).toBeVisible({ timeout: 5_000 })
+    await expect(alert).toBeVisible()
     await expect(alert.getByText(/retention period/i)).toBeVisible()
     await expect(alert.getByText(/expires on/i)).toBeVisible()
     await expect(alert.getByText(/WRITING|GRADED|SUBMITTED/i)).not.toBeVisible({ timeout: 2_000 })
@@ -83,15 +87,15 @@ test.describe('Thesis Delete (Anonymize) - Admin', () => {
     await page.getByText('Configuration').click()
 
     const deleteButton = page.getByRole('button', { name: 'Anonymize Thesis' })
-    await expect(deleteButton).toBeVisible({ timeout: 5_000 })
+    await expect(deleteButton).toBeVisible()
     await deleteButton.click()
 
     const dialog = page.getByRole('dialog')
-    await expect(dialog).toBeVisible({ timeout: 5_000 })
+    await expect(dialog).toBeVisible()
 
     // Active (WRITING) thesis should show state warning
     const alert = dialog.locator('.mantine-Alert-root')
-    await expect(alert).toBeVisible({ timeout: 5_000 })
+    await expect(alert).toBeVisible()
     await expect(alert.getByText(/WRITING/i)).toBeVisible()
     // Should also show retention warning since thesis is only 30 days old
     await expect(alert.getByText(/retention period/i)).toBeVisible()

--- a/client/e2e/thesis-delete.spec.ts
+++ b/client/e2e/thesis-delete.spec.ts
@@ -1,24 +1,45 @@
-import { test, expect } from '@playwright/test'
+import { test, expect, TestInfo } from '@playwright/test'
 import { authStatePath, navigateToDetail } from './helpers'
 
-const OLD_THESIS_ID = '00000000-0000-4000-d000-000000000010'
-const RECENT_THESIS_ID = '00000000-0000-4000-d000-000000000011'
-const ACTIVE_THESIS_ID = '00000000-0000-4000-d000-000000000012'
+// Anonymization is irreversible. Once a test attempt anonymizes a thesis, a
+// Playwright retry against the same row would fail at the "Anonymize Thesis"
+// button visibility check (the button is gated on !anonymizedAt). Each test
+// attempt therefore uses a different seed thesis, indexed by `testInfo.retry`.
+// The retry-slot rows (suffixes a0/b0/a1/b1/a2/b2) are seeded with identical
+// state and dates to their base counterparts in seed_dev_test_data.sql.
+const OLD_THESIS_IDS = [
+  '00000000-0000-4000-d000-000000000010',
+  '00000000-0000-4000-d000-0000000000a0',
+  '00000000-0000-4000-d000-0000000000b0',
+]
+const RECENT_THESIS_IDS = [
+  '00000000-0000-4000-d000-000000000011',
+  '00000000-0000-4000-d000-0000000000a1',
+  '00000000-0000-4000-d000-0000000000b1',
+]
+const ACTIVE_THESIS_IDS = [
+  '00000000-0000-4000-d000-000000000012',
+  '00000000-0000-4000-d000-0000000000a2',
+  '00000000-0000-4000-d000-0000000000b2',
+]
 // Thesis 1 — always available, examiner has EXAMINER role on it
 const EXAMINER_THESIS_ID = '00000000-0000-4000-d000-000000000001'
+
+function thesisIdForAttempt(ids: string[], info: TestInfo): string {
+  // Fall through to the last id if a developer raises `retries` beyond the
+  // configured slots — better to reuse than crash with an out-of-range lookup.
+  return ids[Math.min(info.retry, ids.length - 1)]
+}
 
 test.describe('Thesis Delete (Anonymize) - Admin', () => {
   test.use({ storageState: authStatePath('admin') })
 
-  // Anonymization is irreversible, so the seed rows mutated by these tests cannot
-  // be restored mid-run. Retrying after a partial success would fail on the
-  // already-anonymized state and mask the real cause; disable retries so any flake
-  // surfaces as a first-attempt failure with the actual error.
-  test.describe.configure({ mode: 'serial', retries: 0 })
+  test.describe.configure({ mode: 'serial' })
 
-  test('admin can anonymize old non-terminal thesis with state warning only', async ({ page }) => {
+  test('admin can anonymize old non-terminal thesis with state warning only', async ({ page }, testInfo) => {
+    const thesisId = thesisIdForAttempt(OLD_THESIS_IDS, testInfo)
     const heading = page.getByRole('heading', { name: /Historical Analysis of Compiler/i })
-    await navigateToDetail(page, `/theses/${OLD_THESIS_ID}`, heading)
+    await navigateToDetail(page, `/theses/${thesisId}`, heading)
 
     // Open Configuration accordion
     await page.getByText('Configuration').click()
@@ -54,9 +75,10 @@ test.describe('Thesis Delete (Anonymize) - Admin', () => {
     await expect(page).toHaveURL(/\/theses(?:\?|$)/, { timeout: 15_000 })
   })
 
-  test('admin can anonymize recent thesis with retention warning', async ({ page }) => {
+  test('admin can anonymize recent thesis with retention warning', async ({ page }, testInfo) => {
+    const thesisId = thesisIdForAttempt(RECENT_THESIS_IDS, testInfo)
     const heading = page.getByRole('heading', { name: /Machine Learning Approaches/i })
-    await navigateToDetail(page, `/theses/${RECENT_THESIS_ID}`, heading)
+    await navigateToDetail(page, `/theses/${thesisId}`, heading)
 
     await page.getByText('Configuration').click()
 
@@ -80,9 +102,10 @@ test.describe('Thesis Delete (Anonymize) - Admin', () => {
     await expect(page).toHaveURL(/\/theses(?:\?|$)/, { timeout: 15_000 })
   })
 
-  test('admin can anonymize active thesis with state and retention warnings', async ({ page }) => {
+  test('admin can anonymize active thesis with state and retention warnings', async ({ page }, testInfo) => {
+    const thesisId = thesisIdForAttempt(ACTIVE_THESIS_IDS, testInfo)
     const heading = page.getByRole('heading', { name: /Real-Time Anomaly Detection/i })
-    await navigateToDetail(page, `/theses/${ACTIVE_THESIS_ID}`, heading)
+    await navigateToDetail(page, `/theses/${thesisId}`, heading)
 
     await page.getByText('Configuration').click()
 

--- a/client/src/pages/ThesisPage/components/ThesisConfigSection/ThesisConfigSection.tsx
+++ b/client/src/pages/ThesisPage/components/ThesisConfigSection/ThesisConfigSection.tsx
@@ -29,7 +29,7 @@ import { GLOBAL_CONFIG } from '../../../../config/global'
 import { ApiError, getApiResponseErrorMessage } from '../../../../requests/handler'
 import ThesisStateBadge from '../../../../components/ThesisStateBadge/ThesisStateBadge'
 import ThesisVisibilitySelect from '../ThesisVisibilitySelect/ThesisVisibilitySelect'
-import { formatThesisType } from '../../../../utils/format'
+import { formatThesisState, formatThesisType } from '../../../../utils/format'
 import LanguageSelect from '../../../../components/LanguageSelect/LanguageSelect'
 import type { PaginationResponse } from '../../../../requests/responses/pagination'
 import type { ILightResearchGroup } from '../../../../requests/responses/researchGroup'
@@ -226,6 +226,25 @@ const ThesisConfigSection = () => {
       throw new Error(`Failed to close thesis ${response.status}`)
     }
   }, 'Thesis closed successfully')
+
+  const orderedStates = [...(thesis.states ?? [])].sort(
+    (a, b) => new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime(),
+  )
+  const previousState = orderedStates[1]?.state
+  const canRevert = access.supervisor && orderedStates.length >= 2 && !thesis.anonymizedAt
+
+  const [reverting, onRevert] = useThesisUpdateAction(async () => {
+    const response = await doRequest<IThesis>(`/v2/theses/${thesis.thesisId}/revert-state`, {
+      method: 'POST',
+      requiresAuth: true,
+    })
+
+    if (response.ok) {
+      return response.data
+    } else {
+      throw new ApiError(response)
+    }
+  }, 'Thesis state reverted successfully')
 
   const onDeleteThesisClick = async () => {
     setAnonymizeLoading(true)
@@ -434,6 +453,18 @@ const ThesisConfigSection = () => {
                         onClick={onClose}
                       >
                         Close Thesis
+                      </ConfirmationButton>
+                    )}
+                    {canRevert && previousState && (
+                      <ConfirmationButton
+                        confirmationTitle='Revert Thesis State'
+                        confirmationText={`Revert from ${formatThesisState(thesis.state)} back to ${formatThesisState(previousState)}? Data captured in ${formatThesisState(thesis.state)} (assessment, final grade, proposal approval, etc.) will be preserved.`}
+                        variant='outline'
+                        color='yellow'
+                        loading={reverting}
+                        onClick={onRevert}
+                      >
+                        Revert to Previous State
                       </ConfirmationButton>
                     )}
                     {hasAdminAccess && !thesis.anonymizedAt && (

--- a/docs/superpowers/specs/2026-05-14-revert-thesis-state-design.md
+++ b/docs/superpowers/specs/2026-05-14-revert-thesis-state-design.md
@@ -1,0 +1,131 @@
+# Revert Thesis State
+
+**Issue:** [#949](https://github.com/ls1intum/thesis-management/issues/949) — Bug: Can't revert student state from writing to proposal.
+
+## Problem
+
+The thesis lifecycle is forward-only: states (`PROPOSAL` → `WRITING` → `SUBMITTED` → `ASSESSED` → `GRADED` → `FINISHED`, plus the side branch `DROPPED_OUT`) are advanced via dedicated buttons (`acceptProposal`, `submitThesis`, `submitAssessment`, `gradeThesis`, `completeThesis`, `closeThesis`). Once advanced, there is no UI path to go back.
+
+If a supervisor or examiner clicks the wrong button — or needs to reopen a `FINISHED` thesis because a required document was never uploaded — the only workaround is to edit the `changedAt` timestamps in the Configuration section, which does not change the current state. The reported bug is exactly this: changing the date of `WRITING` does not move the thesis out of `WRITING`.
+
+## Goal
+
+Let supervisors and examiners revert a thesis one state at a time. Repeated clicks can walk further back. Side data (proposal approval, assessment, final grade) is preserved so the supervisor can re-advance without re-entering values.
+
+## UX
+
+A new **"Revert to Previous State"** button in the Configuration section, next to the existing "Close Thesis" / "Update" buttons. Visible only when:
+
+- `access.supervisor` is true (covers supervisors and examiners), AND
+- `thesis.states.length >= 2` (i.e., the thesis is not still in its initial state).
+
+Clicking it opens a confirmation dialog:
+
+> Revert the thesis state from **[CurrentState]** back to **[PreviousState]**? Data captured in [CurrentState] (assessment, final grade, proposal approval, etc.) will be preserved.
+
+On confirmation the request is sent; on success the thesis reloads and the `ThesisStateBadge` in the header reflects the previous state.
+
+## Backend
+
+### Endpoint
+
+`POST /v2/theses/{thesisId}/revert-state`
+
+- Auth: caller must have supervisor access on the thesis (`thesis.hasSupervisorAccess(currentUser)`), same check used by `acceptProposal`, `submitThesis`, etc.
+- Returns the updated `ThesisDto`.
+
+### Service method
+
+`ThesisService.revertToPreviousState(Thesis thesis)`:
+
+1. `requireNotAnonymized(thesis)`.
+2. `assertCanAccessResearchGroup`.
+3. Order `thesis.getStates()` by `changedAt DESC`. If fewer than two entries, throw `ResourceInvalidParametersException("Thesis has no previous state to revert to")`.
+4. `currentChange` = first; `previousState` = second's state.
+5. Capture `wasReopened = currentChange.state in (FINISHED, DROPPED_OUT)`.
+6. Delete the `currentChange` row via `thesisStateChangeRepository.deleteById(currentChange.getId())` and remove it from the in-memory `thesis.getStates()` set.
+7. `thesis.setState(previousState)`.
+8. `thesis = thesisRepository.save(thesis)`.
+9. If `wasReopened`: for each `student` in `thesis.getStudents()`, call `accessManagementService.addStudentGroup(student)` so the student regains application access. (Mirrors `closeThesis` / `completeThesis`, in reverse.)
+10. Return the saved thesis.
+
+### Data preservation
+
+We do not clear:
+
+- `proposal.approvedAt` / `approvedBy` when reverting from `WRITING` to `PROPOSAL`
+- assessment entities when reverting from `ASSESSED` to `SUBMITTED`
+- `finalGrade` / `finalFeedback` when reverting from `GRADED` to `ASSESSED`
+
+This is intentional. The supervisor can re-advance and the existing values populate the forms. If they were destructive operations they would amplify the cost of a single misclick.
+
+### No mailing
+
+Reverting is an admin-correction action and does not send emails. The original forward-action email is already in the wild; we don't try to undo it.
+
+## Frontend
+
+### Request
+
+```ts
+const [reverting, onRevert] = useThesisUpdateAction(async () => {
+  const response = await doRequest<IThesis>(
+    `/v2/theses/${thesis.thesisId}/revert-state`,
+    { method: 'POST', requiresAuth: true },
+  )
+  if (response.ok) return response.data
+  throw new ApiError(response)
+}, 'Thesis state reverted successfully')
+```
+
+### Button
+
+In `ThesisConfigSection.tsx`, alongside "Close Thesis":
+
+```tsx
+{access.supervisor && (thesis.states?.length ?? 0) >= 2 && (
+  <ConfirmationButton
+    confirmationTitle='Revert Thesis State'
+    confirmationText={`Revert from ${currentState} back to ${previousState}? Data captured in ${currentState} will be preserved.`}
+    variant='outline'
+    color='yellow'
+    loading={reverting}
+    onClick={onRevert}
+  >
+    Revert to Previous State
+  </ConfirmationButton>
+)}
+```
+
+The current/previous state labels come from the latest two entries in `thesis.states` sorted by `startedAt`.
+
+## Edge cases
+
+- **Anonymized thesis:** blocked server-side by `requireNotAnonymized`. The button can also be hidden when `thesis.anonymizedAt` is set, but the server check is the source of truth.
+- **Initial state (single state change):** button hidden client-side; server returns 400 if called anyway.
+- **Concurrent reverts:** relies on existing per-call Spring Data transactions.
+- **Reverting a thesis whose student no longer exists:** `getStudents()` returns an empty list, group restoration is a no-op.
+
+## Testing
+
+### Server
+
+- `ThesisServiceTest`:
+  - Revert from `WRITING` → state becomes `PROPOSAL`, only one state change remains, proposal approval preserved.
+  - Revert from `FINISHED` → state becomes `GRADED`, `addStudentGroup` invoked for each student.
+  - Revert from `DROPPED_OUT` → state becomes prior state, `addStudentGroup` invoked.
+  - Revert with only one state entry → throws `ResourceInvalidParametersException`.
+  - Revert anonymized thesis → throws.
+- `ThesisControllerTest` (or `ThesisControllerAdditionalTest`):
+  - Supervisor: 200 + updated DTO.
+  - Non-supervisor (student): 403.
+
+### Client / e2e
+
+Extend `client/e2e/thesis-lifecycle-workflow.spec.ts` (or add a small spec) to: accept proposal → assert state `WRITING` → click "Revert to Previous State" → confirm → assert state `PROPOSAL`.
+
+## Out of scope
+
+- Jumping multiple states in one action (still requires repeated clicks).
+- Clearing forward-state data on revert.
+- Reverting via the public API.

--- a/server/src/main/java/de/tum/cit/aet/thesis/controller/ThesisController.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/controller/ThesisController.java
@@ -988,6 +988,30 @@ public class ThesisController {
 		return ResponseEntity.ok(ThesisDto.fromThesisEntity(thesis, thesis.hasSupervisorAccess(currentUser), thesis.hasStudentAccess(currentUser)));
 	}
 
+	/* REVERT ENDPOINTS */
+
+	/**
+	 * Reverts the thesis one state backwards in case of an accidental forward transition.
+	 *
+	 * @param thesisId the unique identifier of the thesis to revert
+	 * @return the updated thesis after reverting
+	 */
+	@PostMapping("/{thesisId}/revert-state")
+	public ResponseEntity<ThesisDto> revertThesisState(
+			@PathVariable UUID thesisId
+	) {
+		User currentUser = currentUserProvider().getUser();
+		Thesis thesis = thesisService.findById(thesisId);
+
+		if (!thesis.hasSupervisorAccess(currentUser)) {
+			throw new AccessDeniedException("You need to be a supervisor or examiner of this thesis to revert its state");
+		}
+
+		thesis = thesisService.revertToPreviousState(thesis);
+
+		return ResponseEntity.ok(ThesisDto.fromThesisEntity(thesis, thesis.hasSupervisorAccess(currentUser), thesis.hasStudentAccess(currentUser)));
+	}
+
 	/* ANONYMIZATION ENDPOINTS */
 
 	/**

--- a/server/src/main/java/de/tum/cit/aet/thesis/service/ThesisService.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/service/ThesisService.java
@@ -853,12 +853,15 @@ public class ThesisService {
 	 * in {@code FINISHED} or {@code DROPPED_OUT}, the student group is restored for each
 	 * student, mirroring the inverse of {@link #completeThesis(Thesis)} / {@link #closeThesis(Thesis)}.
 	 *
+	 * <p>Operations are ordered so a partial failure leaves the system in a recoverable state:
+	 * the thesis state row is updated first (user-visible), then the historical state change
+	 * is removed, and finally the student group is restored. If the row deletion fails, a
+	 * retry will re-derive the same {@code currentChange} and complete the cleanup idempotently.
+	 *
 	 * @param thesis the thesis to revert
 	 * @return the updated thesis
 	 * @throws ResourceInvalidParametersException if the thesis is anonymized or has no previous state
 	 */
-	// TODO: we should avoid using @Transactional because it can lead to performance issue and concurrency problems
-	@Transactional
 	public Thesis revertToPreviousState(Thesis thesis) {
 		requireNotAnonymized(thesis);
 		currentUserProvider().assertCanAccessResearchGroup(thesis.getResearchGroup());
@@ -872,24 +875,25 @@ public class ThesisService {
 		}
 
 		ThesisStateChange currentChange = orderedStates.get(0);
+		ThesisStateChangeId currentChangeId = currentChange.getId();
 		ThesisState previousState = orderedStates.get(1).getId().getState();
-		ThesisState revertedFrom = currentChange.getId().getState();
-
-		thesisStateChangeRepository.deleteById(currentChange.getId());
-		Set<ThesisStateChange> remaining = new HashSet<>(thesis.getStates());
-		remaining.remove(currentChange);
-		thesis.setStates(remaining);
+		ThesisState revertedFrom = currentChangeId.getState();
 
 		thesis.setState(previousState);
-		thesis = thesisRepository.save(thesis);
+		Thesis savedThesis = thesisRepository.save(thesis);
+
+		thesisStateChangeRepository.deleteById(currentChangeId);
+		Set<ThesisStateChange> remaining = new HashSet<>(savedThesis.getStates());
+		remaining.removeIf(sc -> sc.getId().equals(currentChangeId));
+		savedThesis.setStates(remaining);
 
 		if (revertedFrom == ThesisState.FINISHED || revertedFrom == ThesisState.DROPPED_OUT) {
-			for (User student : thesis.getStudents()) {
+			for (User student : savedThesis.getStudents()) {
 				accessManagementService.addStudentGroup(student);
 			}
 		}
 
-		return thesis;
+		return savedThesis;
 	}
 
 	/* UTILITY */

--- a/server/src/main/java/de/tum/cit/aet/thesis/service/ThesisService.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/service/ThesisService.java
@@ -842,6 +842,56 @@ public class ThesisService {
 		return thesis;
 	}
 
+	/* REVERT */
+
+	/**
+	 * Reverts the thesis one state backwards by deleting the latest state change record and
+	 * setting the thesis state to the previous one in the history.
+	 *
+	 * <p>Side data (proposal approval, assessment entities, final grade) is intentionally
+	 * preserved so the supervisor can re-advance without re-entering it. If the thesis was
+	 * in {@code FINISHED} or {@code DROPPED_OUT}, the student group is restored for each
+	 * student, mirroring the inverse of {@link #completeThesis(Thesis)} / {@link #closeThesis(Thesis)}.
+	 *
+	 * @param thesis the thesis to revert
+	 * @return the updated thesis
+	 * @throws ResourceInvalidParametersException if the thesis is anonymized or has no previous state
+	 */
+	// TODO: we should avoid using @Transactional because it can lead to performance issue and concurrency problems
+	@Transactional
+	public Thesis revertToPreviousState(Thesis thesis) {
+		requireNotAnonymized(thesis);
+		currentUserProvider().assertCanAccessResearchGroup(thesis.getResearchGroup());
+
+		List<ThesisStateChange> orderedStates = thesis.getStates().stream()
+				.sorted(Comparator.comparing(ThesisStateChange::getChangedAt).reversed())
+				.toList();
+
+		if (orderedStates.size() < 2) {
+			throw new ResourceInvalidParametersException("Thesis has no previous state to revert to");
+		}
+
+		ThesisStateChange currentChange = orderedStates.get(0);
+		ThesisState previousState = orderedStates.get(1).getId().getState();
+		ThesisState revertedFrom = currentChange.getId().getState();
+
+		thesisStateChangeRepository.deleteById(currentChange.getId());
+		Set<ThesisStateChange> remaining = new HashSet<>(thesis.getStates());
+		remaining.remove(currentChange);
+		thesis.setStates(remaining);
+
+		thesis.setState(previousState);
+		thesis = thesisRepository.save(thesis);
+
+		if (revertedFrom == ThesisState.FINISHED || revertedFrom == ThesisState.DROPPED_OUT) {
+			for (User student : thesis.getStudents()) {
+				accessManagementService.addStudentGroup(student);
+			}
+		}
+
+		return thesis;
+	}
+
 	/* UTILITY */
 
 	private boolean existsPendingThesis(User user) {

--- a/server/src/main/resources/db/changelog/manual/seed_dev_test_data.sql
+++ b/server/src/main/resources/db/changelog/manual/seed_dev_test_data.sql
@@ -1522,6 +1522,99 @@ VALUES
     ('00000000-0000-4000-d000-000000000012'::UUID, 'WRITING', NOW() - INTERVAL '20 days')
 ON CONFLICT DO NOTHING;
 
+-- Retry slots for the admin anonymize tests in client/e2e/thesis-delete.spec.ts.
+-- Anonymization is irreversible: once a test attempt anonymizes thesis 10/11/12,
+-- a Playwright retry against the same row fails at the "Anonymize Thesis" button
+-- visibility check (the button is gated on !anonymizedAt) and reports a misleading
+-- "element not found" instead of the real first-attempt failure. Each test attempt
+-- picks a different thesis ID via `testInfo.retry`, so every attempt gets a fresh,
+-- non-anonymized row. CI runs initial + 2 retries → 2 retry slots per scenario.
+-- Warnings depend only on `state` and `end_date`, so roles/state_changes/comments
+-- are intentionally omitted; the test does not assert on them.
+INSERT INTO theses (thesis_id, title, type, language, metadata, info, abstract, state,
+                    visibility, keywords, application_id, start_date, end_date, created_at,
+                    research_group_id)
+VALUES
+    -- OLD retry 1 (mirrors thesis 10: GRADED, retention expired)
+    ('00000000-0000-4000-d000-0000000000a0'::UUID,
+     'Historical Analysis of Compiler Optimization Techniques',
+     'MASTER', 'ENGLISH',
+     '{"titles":{},"credits":{}}',
+     'Comprehensive analysis of compiler optimization strategies across different architectures.',
+     'This thesis examines historical compiler optimization techniques and their evolution.',
+     'GRADED', 'PRIVATE',
+     ARRAY['compilers', 'optimization'],
+     NULL,
+     NOW() - INTERVAL '2800 days', NOW() - INTERVAL '2600 days',
+     NOW() - INTERVAL '2800 days',
+     '00000000-0000-4000-a000-000000000001'::UUID),
+    -- OLD retry 2
+    ('00000000-0000-4000-d000-0000000000b0'::UUID,
+     'Historical Analysis of Compiler Optimization Techniques',
+     'MASTER', 'ENGLISH',
+     '{"titles":{},"credits":{}}',
+     'Comprehensive analysis of compiler optimization strategies across different architectures.',
+     'This thesis examines historical compiler optimization techniques and their evolution.',
+     'GRADED', 'PRIVATE',
+     ARRAY['compilers', 'optimization'],
+     NULL,
+     NOW() - INTERVAL '2800 days', NOW() - INTERVAL '2600 days',
+     NOW() - INTERVAL '2800 days',
+     '00000000-0000-4000-a000-000000000001'::UUID),
+    -- RECENT retry 1 (mirrors thesis 11: FINISHED, retention not expired)
+    ('00000000-0000-4000-d000-0000000000a1'::UUID,
+     'Machine Learning Approaches to Code Review Automation',
+     'MASTER', 'ENGLISH',
+     '{"titles":{},"credits":{}}',
+     'An evaluation of ML-based approaches for automating code review processes.',
+     'This thesis proposes a machine learning framework for automated code review.',
+     'FINISHED', 'PRIVATE',
+     ARRAY['machine learning', 'code review'],
+     NULL,
+     NOW() - INTERVAL '800 days', NOW() - INTERVAL '620 days',
+     NOW() - INTERVAL '800 days',
+     '00000000-0000-4000-a000-000000000001'::UUID),
+    -- RECENT retry 2
+    ('00000000-0000-4000-d000-0000000000b1'::UUID,
+     'Machine Learning Approaches to Code Review Automation',
+     'MASTER', 'ENGLISH',
+     '{"titles":{},"credits":{}}',
+     'An evaluation of ML-based approaches for automating code review processes.',
+     'This thesis proposes a machine learning framework for automated code review.',
+     'FINISHED', 'PRIVATE',
+     ARRAY['machine learning', 'code review'],
+     NULL,
+     NOW() - INTERVAL '800 days', NOW() - INTERVAL '620 days',
+     NOW() - INTERVAL '800 days',
+     '00000000-0000-4000-a000-000000000001'::UUID),
+    -- ACTIVE retry 1 (mirrors thesis 12: WRITING, retention not expired)
+    ('00000000-0000-4000-d000-0000000000a2'::UUID,
+     'Real-Time Anomaly Detection in Distributed Systems',
+     'BACHELOR', 'ENGLISH',
+     '{"titles":{},"credits":{}}',
+     'Exploring anomaly detection techniques for distributed microservice architectures.',
+     'This thesis designs a real-time anomaly detection system for distributed environments.',
+     'WRITING', 'PRIVATE',
+     ARRAY['anomaly detection', 'distributed systems'],
+     NULL,
+     NOW() - INTERVAL '30 days', NOW() + INTERVAL '150 days',
+     NOW() - INTERVAL '30 days',
+     '00000000-0000-4000-a000-000000000001'::UUID),
+    -- ACTIVE retry 2
+    ('00000000-0000-4000-d000-0000000000b2'::UUID,
+     'Real-Time Anomaly Detection in Distributed Systems',
+     'BACHELOR', 'ENGLISH',
+     '{"titles":{},"credits":{}}',
+     'Exploring anomaly detection techniques for distributed microservice architectures.',
+     'This thesis designs a real-time anomaly detection system for distributed environments.',
+     'WRITING', 'PRIVATE',
+     ARRAY['anomaly detection', 'distributed systems'],
+     NULL,
+     NOW() - INTERVAL '30 days', NOW() + INTERVAL '150 days',
+     NOW() - INTERVAL '30 days',
+     '00000000-0000-4000-a000-000000000001'::UUID)
+ON CONFLICT DO NOTHING;
+
 -- Thesis 10-12 comments
 INSERT INTO thesis_comments (comment_id, thesis_id, type, message, filename, upload_name,
                              created_at, created_by)

--- a/server/src/test/java/de/tum/cit/aet/thesis/controller/ThesisControllerTest.java
+++ b/server/src/test/java/de/tum/cit/aet/thesis/controller/ThesisControllerTest.java
@@ -547,6 +547,57 @@ class ThesisControllerTest extends BaseIntegrationTest {
 		}
 
 		@Test
+		void revertThesisState_Success() throws Exception {
+			String authorization = createRandomAdminAuthentication();
+			UUID thesisId = createTestThesis("Test Thesis");
+			createTestEmailTemplate("THESIS_PROPOSAL_UPLOADED");
+			createTestEmailTemplate("THESIS_PROPOSAL_ACCEPTED");
+
+			MockMultipartFile proposalFile = new MockMultipartFile(
+					"proposal", "test.pdf", MediaType.APPLICATION_PDF_VALUE, "test content".getBytes()
+			);
+
+			mockMvc.perform(MockMvcRequestBuilders.multipart("/v2/theses/{thesisId}/proposal", thesisId)
+							.file(proposalFile)
+							.header("Authorization", authorization))
+					.andExpect(status().isOk());
+
+			mockMvc.perform(MockMvcRequestBuilders.put("/v2/theses/{thesisId}/proposal/accept", thesisId)
+							.header("Authorization", authorization))
+					.andExpect(status().isOk());
+
+			assertThat(thesisRepository.findById(thesisId).orElseThrow().getState())
+					.isEqualTo(ThesisState.WRITING);
+
+			mockMvc.perform(MockMvcRequestBuilders.post("/v2/theses/{thesisId}/revert-state", thesisId)
+							.header("Authorization", authorization))
+					.andExpect(status().isOk());
+
+			Thesis thesis = thesisRepository.findById(thesisId).orElseThrow();
+			assertThat(thesis.getState()).isEqualTo(ThesisState.PROPOSAL);
+			assertThat(thesis.getStates()).hasSize(1);
+		}
+
+		@Test
+		void revertThesisState_OnlyInitialState_BadRequest() throws Exception {
+			String authorization = createRandomAdminAuthentication();
+			UUID thesisId = createTestThesis("Test Thesis");
+
+			mockMvc.perform(MockMvcRequestBuilders.post("/v2/theses/{thesisId}/revert-state", thesisId)
+							.header("Authorization", authorization))
+					.andExpect(status().isBadRequest());
+		}
+
+		@Test
+		void revertThesisState_AccessDenied_AsStudent() throws Exception {
+			UUID thesisId = createTestThesis("Test Thesis");
+
+			mockMvc.perform(MockMvcRequestBuilders.post("/v2/theses/{thesisId}/revert-state", thesisId)
+							.header("Authorization", createRandomAuthentication("student")))
+					.andExpect(status().isForbidden());
+		}
+
+		@Test
 		void getProposalFile_Success() throws Exception {
 			UUID thesisId = createTestThesis("Test Thesis");
 			createTestEmailTemplate("THESIS_PROPOSAL_UPLOADED");

--- a/server/src/test/java/de/tum/cit/aet/thesis/service/ThesisServiceTest.java
+++ b/server/src/test/java/de/tum/cit/aet/thesis/service/ThesisServiceTest.java
@@ -15,7 +15,9 @@ import de.tum.cit.aet.thesis.entity.Thesis;
 import de.tum.cit.aet.thesis.entity.ThesisAssessment;
 import de.tum.cit.aet.thesis.entity.ThesisFile;
 import de.tum.cit.aet.thesis.entity.ThesisProposal;
+import de.tum.cit.aet.thesis.entity.ThesisStateChange;
 import de.tum.cit.aet.thesis.entity.User;
+import de.tum.cit.aet.thesis.entity.key.ThesisStateChangeId;
 import de.tum.cit.aet.thesis.exception.request.ResourceInvalidParametersException;
 import de.tum.cit.aet.thesis.exception.request.ResourceNotFoundException;
 import de.tum.cit.aet.thesis.mock.EntityMockFactory;
@@ -39,10 +41,13 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 @ExtendWith(MockitoExtension.class)
@@ -226,6 +231,75 @@ class ThesisServiceTest {
 		assertEquals(ThesisVisibility.INTERNAL, result.getVisibility());
 		verify(thesisRepository).save(testThesis);
 		verify(mailingService).sendFinalGradeEmail(testThesis);
+	}
+
+	@Test
+	void revertToPreviousState_WithSingleState_ThrowsException() {
+		testThesis.setStates(new HashSet<>(Set.of(
+				stateChange(testThesis.getId(), ThesisState.PROPOSAL, Instant.parse("2026-01-01T10:00:00Z"))
+		)));
+
+		assertThrows(ResourceInvalidParametersException.class, () ->
+				thesisService.revertToPreviousState(testThesis)
+		);
+	}
+
+	@Test
+	void revertToPreviousState_WithMultipleStates_RevertsAndDeletesLatest() {
+		ThesisStateChange proposal = stateChange(testThesis.getId(), ThesisState.PROPOSAL, Instant.parse("2026-01-01T10:00:00Z"));
+		ThesisStateChange writing = stateChange(testThesis.getId(), ThesisState.WRITING, Instant.parse("2026-02-01T10:00:00Z"));
+		testThesis.setState(ThesisState.WRITING);
+		testThesis.setStates(new HashSet<>(Set.of(proposal, writing)));
+		when(thesisRepository.save(any(Thesis.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+		Thesis result = thesisService.revertToPreviousState(testThesis);
+
+		assertEquals(ThesisState.PROPOSAL, result.getState());
+		verify(thesisStateChangeRepository).deleteById(writing.getId());
+		verify(thesisRepository).save(testThesis);
+	}
+
+	@Test
+	void revertToPreviousState_FromFinished_RestoresStudentGroup() {
+		User student = EntityMockFactory.createUserWithGroup("Student", "student");
+		EntityMockFactory.setupThesisRole(testThesis, student, ThesisRoleName.STUDENT);
+		ThesisStateChange graded = stateChange(testThesis.getId(), ThesisState.GRADED, Instant.parse("2026-03-01T10:00:00Z"));
+		ThesisStateChange finished = stateChange(testThesis.getId(), ThesisState.FINISHED, Instant.parse("2026-04-01T10:00:00Z"));
+		testThesis.setState(ThesisState.FINISHED);
+		testThesis.setStates(new HashSet<>(Set.of(graded, finished)));
+		when(thesisRepository.save(any(Thesis.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+		Thesis result = thesisService.revertToPreviousState(testThesis);
+
+		assertEquals(ThesisState.GRADED, result.getState());
+		verify(accessManagementService).addStudentGroup(student);
+	}
+
+	@Test
+	void revertToPreviousState_FromDroppedOut_RestoresStudentGroup() {
+		User student = EntityMockFactory.createUserWithGroup("Student", "student");
+		EntityMockFactory.setupThesisRole(testThesis, student, ThesisRoleName.STUDENT);
+		ThesisStateChange writing = stateChange(testThesis.getId(), ThesisState.WRITING, Instant.parse("2026-02-01T10:00:00Z"));
+		ThesisStateChange dropped = stateChange(testThesis.getId(), ThesisState.DROPPED_OUT, Instant.parse("2026-03-01T10:00:00Z"));
+		testThesis.setState(ThesisState.DROPPED_OUT);
+		testThesis.setStates(new HashSet<>(Set.of(writing, dropped)));
+		when(thesisRepository.save(any(Thesis.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+		Thesis result = thesisService.revertToPreviousState(testThesis);
+
+		assertEquals(ThesisState.WRITING, result.getState());
+		verify(accessManagementService).addStudentGroup(student);
+	}
+
+	private ThesisStateChange stateChange(UUID thesisId, ThesisState state, Instant changedAt) {
+		ThesisStateChangeId id = new ThesisStateChangeId();
+		id.setThesisId(thesisId);
+		id.setState(state);
+		ThesisStateChange change = new ThesisStateChange();
+		change.setId(id);
+		change.setThesis(testThesis);
+		change.setChangedAt(changedAt);
+		return change;
 	}
 
 	@Test


### PR DESCRIPTION
## Summary

- Adds a **Revert to Previous State** button in the thesis Configuration section so supervisors and examiners can undo an accidental forward state transition (e.g. clicking *Accept Proposal* on the wrong thesis, or needing to reopen a `FINISHED` thesis because a required document was never uploaded).
- New `POST /v2/theses/{thesisId}/revert-state` endpoint, gated by supervisor access, that deletes the latest `thesis_state_changes` entry and sets the thesis state to the previous one. When reverting from `FINISHED` or `DROPPED_OUT`, the student group is re-added so the student regains access.
- Side data (proposal approval, assessment, final grade) is preserved so the supervisor can re-advance without re-entering values.

Closes #949.

## Why

The thesis lifecycle was forward-only. The Configuration section let supervisors edit state-change timestamps but never the current state itself, which is exactly the misbehaviour reported in the issue ("changing the date of `WRITING` does not move the thesis out of `WRITING`").

## Design

Full design doc committed at `docs/superpowers/specs/2026-05-14-revert-thesis-state-design.md`.

## Test plan

- [x] `./gradlew test --tests "de.tum.cit.aet.thesis.service.ThesisServiceTest"` — all 14 tests pass, including 4 new ones (single-state guard, basic revert, revert-from-FINISHED restores group, revert-from-DROPPED_OUT restores group)
- [x] `./gradlew test --tests "de.tum.cit.aet.thesis.controller.ThesisControllerTest"` — all 43 tests pass, including 3 new ones (happy path, bad-request on single state, 403 for non-supervisor)
- [x] `./gradlew spotlessCheck` — clean
- [x] `pnpm exec tsc --noEmit` in `client/` — clean
- [x] `pnpm exec eslint` on changed file — no new errors
- [ ] Manual smoke test: accept a proposal, then click *Revert to Previous State* and confirm the state badge returns to `PROPOSAL` and the *Accept Proposal* button reappears
- [ ] Manual smoke test: close a thesis (`DROPPED_OUT`), then revert and verify the student regains access

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New thesis state reversion capability allows supervisors and examiners to revert a thesis to its previous lifecycle state with a confirmation flow integrated in the thesis configuration area.

* **Tests**
  * Added test coverage for thesis state reversion, including authorization checks and edge-case handling.

* **Documentation**
  * Added feature specification documenting thesis state reversion behavior, authorization requirements, and constraints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ls1intum/thesis-management/pull/1042)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->