### PR TITLE
Fix #754: persist application comments on fast applicant switch

### DIFF
--- a/client/e2e/application-comment-autosave.spec.ts
+++ b/client/e2e/application-comment-autosave.spec.ts
@@ -1,0 +1,82 @@
+import { test, expect } from '@playwright/test'
+import { authStatePath, navigateToDetail } from './helpers'
+
+// Regression test for issue #754:
+//   Before the fix, typing a comment and immediately clicking on another
+//   applicant in the sidebar would silently drop the text — the 500ms
+//   auto-save debounce hadn't fired and the form-reset on the application
+//   switch wiped the unsaved value. The fix flushes any pending edit in
+//   the application-switch cleanup; this test guards that behaviour.
+//
+// The seeded applications c000-…-0040 (Student2) and c000-…-0041 (Student3)
+// are dedicated to this test (see seed_dev_test_data.sql §42) so we can
+// rely on Student2/Student3 being the only NOT_ASSESSED sidebar rows for
+// those students when the supervisor opens /applications.
+
+const APPLICATION_A_ID = '00000000-0000-4000-c000-000000000040' // Student2
+const APPLICATION_B_ID = '00000000-0000-4000-c000-000000000041' // Student3
+
+const COMMENT_TEXT = `issue-754 ${Date.now()} ${Math.random().toString(36).slice(2, 8)}`
+
+test.describe('Application comment auto-save — issue #754', () => {
+  test.use({ storageState: authStatePath('supervisor') })
+
+  test('persists a typed comment when the reviewer switches applicants before the debounce fires', async ({
+    page,
+  }) => {
+    // 1. Open applicant A's review page directly so we know exactly which
+    //    application's comment we're editing.
+    const studentAHeading = page.getByRole('heading', { name: /Student2 User/i })
+    await navigateToDetail(page, `/applications/${APPLICATION_A_ID}`, studentAHeading)
+
+    const commentField = page.getByLabel('Comment')
+    await expect(commentField).toBeVisible({ timeout: 15_000 })
+
+    // Resolve applicant B's sidebar row up-front so step 3 below is a bare
+    // click with no preceding waits — that's the timing window the bug
+    // lives in. Student3 has only one NOT_ASSESSED application (the one
+    // seeded in §42), so the regex matches exactly one row in the sidebar.
+    const studentBSidebarItem = page.getByText(/^Student3 User$/).first()
+    await expect(studentBSidebarItem).toBeVisible({ timeout: 15_000 })
+
+    // Clear any leftover text from previous runs and reset the saved
+    // baseline on the server so this test starts from a known state.
+    await commentField.fill('')
+    // Give the 500ms debounce a moment to commit the empty value.
+    await page.waitForTimeout(900)
+
+    // 2. Type a unique comment. Do NOT wait for the debounce — we want to
+    //    switch applicants *before* the auto-save fires (the exact race
+    //    that issue #754 reported).
+    await commentField.fill(COMMENT_TEXT)
+
+    // 3. Immediately click applicant B's sidebar row. No await/visible
+    //    check between fill and click — the whole point is to switch
+    //    inside the 500ms debounce window.
+    await studentBSidebarItem.click()
+
+    // Wait for the URL to flip to applicant B, then for the body to
+    // render the new applicant's heading.
+    await page.waitForURL(`**/applications/${APPLICATION_B_ID}`, { timeout: 15_000 })
+    await expect(page.getByRole('heading', { name: /Student3 User/i })).toBeVisible({
+      timeout: 15_000,
+    })
+
+    // 4. Give the flush PUT a beat to land on the server.
+    await page.waitForTimeout(1000)
+
+    // 5. Click back on applicant A. Force a reload to bypass any client
+    //    cache and prove the comment is in fact persisted server-side.
+    await page.goto(`/applications/${APPLICATION_A_ID}`)
+    await expect(studentAHeading).toBeVisible({ timeout: 15_000 })
+
+    const reloadedCommentField = page.getByLabel('Comment')
+    await expect(reloadedCommentField).toBeVisible({ timeout: 15_000 })
+    await expect(reloadedCommentField).toHaveValue(COMMENT_TEXT, { timeout: 10_000 })
+
+    // 6. Restore the seed state so re-runs (and any other suite that ever
+    //    inspects this application) see a clean comment.
+    await reloadedCommentField.fill('')
+    await page.waitForTimeout(900)
+  })
+})

--- a/client/src/components/ApplicationReviewForm/ApplicationReviewForm.test.tsx
+++ b/client/src/components/ApplicationReviewForm/ApplicationReviewForm.test.tsx
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderWithProviders, screen, userEvent, act } from '../../../test/render'
+import ApplicationReviewForm from './ApplicationReviewForm'
+import { ApplicationState, type IApplication } from '../../requests/responses/application'
+
+// Regression test for issue #754:
+//   Application comments were lost when the reviewer switched to another
+//   applicant before the debounced auto-save fired. The fix flushes any
+//   pending comment edits in the application-switch cleanup so the typed
+//   text is always persisted, even on a fast click-through.
+
+const doRequest = vi.fn()
+vi.mock('../../requests/request', () => ({
+  doRequest: (...args: unknown[]) => doRequest(...args),
+}))
+
+vi.mock('../../hooks/authentication', () => ({
+  useLoggedInUser: () => ({
+    userId: 'reviewer-1',
+    firstName: 'Rev',
+    lastName: 'Iewer',
+    avatar: null,
+    universityId: 'reviewer1',
+    email: 'reviewer@test.local',
+    matriculationNumber: null,
+    studyDegree: null,
+    studyProgram: null,
+    customData: null,
+    joinedAt: '2026-01-01T00:00:00Z',
+  }),
+}))
+
+vi.mock('../../providers/ApplicationsProvider/hooks', () => ({
+  useApplicationsContextUpdater: () => () => undefined,
+}))
+
+const buildApplication = (overrides: Partial<IApplication> = {}): IApplication => ({
+  applicationId: 'app-A',
+  user: {
+    userId: 'student-1',
+    universityId: 'student1',
+    firstName: 'Stu',
+    lastName: 'Dent',
+    email: 'stu@test.local',
+    avatar: null,
+    matriculationNumber: null,
+    studyDegree: 'MASTER',
+    studyProgram: null,
+    customData: null,
+    joinedAt: '2026-01-01T00:00:00Z',
+    researchGroupName: null,
+    researchGroupId: null,
+    gender: null,
+    nationality: null,
+    projects: null,
+    interests: null,
+    specialSkills: null,
+    enrolledAt: null,
+    updatedAt: '2026-01-01T00:00:00Z',
+    hasCv: false,
+    hasDegreeReport: false,
+    hasExaminationReport: false,
+  },
+  topic: null,
+  thesisTitle: 'Some Title',
+  thesisType: 'MASTER',
+  motivation: 'irrelevant',
+  state: ApplicationState.NOT_ASSESSED,
+  desiredStartDate: '2026-06-01',
+  comment: '',
+  createdAt: '2026-05-01T00:00:00Z',
+  reviewers: [],
+  reviewedAt: null,
+  researchGroup: {
+    id: 'rg-1',
+    name: 'Research Group',
+    abbreviation: 'RG',
+    head: {
+      userId: 'head-1',
+      universityId: 'head1',
+      firstName: 'Head',
+      lastName: 'Of Group',
+      email: 'head@test.local',
+      avatar: null,
+      matriculationNumber: null,
+      studyDegree: null,
+      studyProgram: null,
+      customData: null,
+      joinedAt: '2026-01-01T00:00:00Z',
+    },
+  },
+  ...overrides,
+})
+
+const findCommentSaveCalls = (): Array<{ applicationId: string; comment: string }> =>
+  doRequest.mock.calls
+    .filter((call) => /\/v2\/applications\/[^/]+\/comment$/.test(call[0]))
+    .map((call) => {
+      const match = (call[0] as string).match(/\/v2\/applications\/([^/]+)\/comment$/)
+      const options = call[1] as { data?: { comment?: string } }
+      return {
+        applicationId: match?.[1] ?? '',
+        comment: options.data?.comment ?? '',
+      }
+    })
+
+describe('ApplicationReviewForm — issue #754 (comment auto-save)', () => {
+  beforeEach(() => {
+    doRequest.mockReset()
+    // Default: callback-style invocations return a no-op unsubscribe so the
+    // form's auto-save effect doesn't crash. Tests that need to assert on
+    // save success can override per-call behaviour.
+    doRequest.mockImplementation(
+      (
+        _url: string,
+        _options: unknown,
+        cb?: (res: { ok: boolean; status: number; data: unknown }) => void,
+      ) => {
+        // For Promise-style callers we'd return a Promise; the form only
+        // uses the callback form for /comment, so the unsubscribe shape is
+        // sufficient.
+        cb?.({ ok: true, status: 200, data: { comment: '' } })
+        return () => undefined
+      },
+    )
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('saves the typed comment when the user switches applicants before the debounce fires', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime.bind(vi) })
+
+    const appA = buildApplication({ applicationId: 'app-A', comment: '' })
+    const appB = buildApplication({ applicationId: 'app-B', comment: '' })
+
+    const { rerender } = renderWithProviders(<ApplicationReviewForm application={appA} />)
+
+    const textarea = screen.getByLabelText('Comment')
+    await user.type(textarea, 'pending thoughts')
+
+    // Switch to applicant B *before* the 500ms debounce fires. The cleanup
+    // on the application-switch effect must flush the pending edit.
+    rerender(<ApplicationReviewForm application={appB} />)
+
+    const commentCalls = findCommentSaveCalls()
+    expect(
+      commentCalls,
+      'expected one PUT /v2/applications/app-A/comment from the cleanup flush',
+    ).toHaveLength(1)
+    expect(commentCalls[0]).toEqual({
+      applicationId: 'app-A',
+      comment: 'pending thoughts',
+    })
+  })
+
+  it('does not re-save when the typed value matches the last saved baseline', async () => {
+    const user = userEvent.setup()
+
+    const appA = buildApplication({ applicationId: 'app-A', comment: 'already saved' })
+    const appB = buildApplication({ applicationId: 'app-B', comment: '' })
+
+    const { rerender } = renderWithProviders(<ApplicationReviewForm application={appA} />)
+
+    // The textarea is pre-filled from application.comment; touching it
+    // back to the same value must not trigger any save.
+    const textarea = screen.getByLabelText('Comment')
+    await user.click(textarea)
+
+    rerender(<ApplicationReviewForm application={appB} />)
+
+    expect(findCommentSaveCalls()).toHaveLength(0)
+  })
+
+  it('still saves via the debounced effect when the user waits without switching', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime.bind(vi) })
+
+    const appA = buildApplication({ applicationId: 'app-A', comment: '' })
+
+    renderWithProviders(<ApplicationReviewForm application={appA} />)
+
+    const textarea = screen.getByLabelText('Comment')
+    await user.type(textarea, 'leisurely thoughts')
+
+    // Advance past the 500ms debounce so the auto-save effect fires.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(600)
+    })
+
+    const commentCalls = findCommentSaveCalls()
+    expect(commentCalls).toHaveLength(1)
+    expect(commentCalls[0]).toEqual({
+      applicationId: 'app-A',
+      comment: 'leisurely thoughts',
+    })
+  })
+})

--- a/client/src/components/ApplicationReviewForm/ApplicationReviewForm.tsx
+++ b/client/src/components/ApplicationReviewForm/ApplicationReviewForm.tsx
@@ -87,17 +87,15 @@ const ApplicationReviewForm = (props: IApplicationReviewFormProps) => {
   })
 
   // Refs so the application-switch cleanup can read the latest typed comment
-  // and the saved baseline without retriggering the effect.
+  // and the saved baseline without retriggering the effect. Assigned during
+  // render (not in a passive useEffect) so the values are guaranteed fresh
+  // before the useLayoutEffect cleanup below reads them — a passive useEffect
+  // can run *after* a sibling useLayoutEffect cleanup, which would let the
+  // cleanup see a stale comment and persist an older value than the user typed.
   const commentRef = useRef(form.values.comment)
   const savedCommentRef = useRef(application?.comment ?? '')
-
-  useEffect(() => {
-    commentRef.current = form.values.comment
-  }, [form.values.comment])
-
-  useEffect(() => {
-    savedCommentRef.current = application?.comment ?? ''
-  }, [application?.comment])
+  commentRef.current = form.values.comment
+  savedCommentRef.current = application?.comment ?? ''
 
   useLayoutEffect(() => {
     if (application) {

--- a/client/src/components/ApplicationReviewForm/ApplicationReviewForm.tsx
+++ b/client/src/components/ApplicationReviewForm/ApplicationReviewForm.tsx
@@ -3,7 +3,7 @@ import { ApplicationState } from '../../requests/responses/application'
 import { useApplicationsContextUpdater } from '../../providers/ApplicationsProvider/hooks'
 import { isNotEmpty, useForm } from '@mantine/form'
 import { GLOBAL_CONFIG } from '../../config/global'
-import React, { useEffect, useLayoutEffect, useState } from 'react'
+import React, { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { useDebouncedValue } from '@mantine/hooks'
 import { doRequest } from '../../requests/request'
 import {
@@ -86,6 +86,19 @@ const ApplicationReviewForm = (props: IApplicationReviewFormProps) => {
     },
   })
 
+  // Refs so the application-switch cleanup can read the latest typed comment
+  // and the saved baseline without retriggering the effect.
+  const commentRef = useRef(form.values.comment)
+  const savedCommentRef = useRef(application?.comment ?? '')
+
+  useEffect(() => {
+    commentRef.current = form.values.comment
+  }, [form.values.comment])
+
+  useEffect(() => {
+    savedCommentRef.current = application?.comment ?? ''
+  }, [application?.comment])
+
   useLayoutEffect(() => {
     if (application) {
       form.setInitialValues({
@@ -110,12 +123,37 @@ const ApplicationReviewForm = (props: IApplicationReviewFormProps) => {
     }
 
     form.reset()
+
+    // When the application changes (or the component unmounts), flush any
+    // pending comment edits for the application we are leaving — otherwise a
+    // fast switch before the debounce fires would silently drop the text.
+    const leavingApplicationId = application?.applicationId
+    const leavingBaseline = application?.comment ?? ''
+    return () => {
+      if (!leavingApplicationId) return
+      const pendingComment = commentRef.current
+      if (pendingComment === leavingBaseline) return
+      if (pendingComment === savedCommentRef.current) return
+      doRequest<IApplication>(
+        `/v2/applications/${leavingApplicationId}/comment`,
+        {
+          method: 'PUT',
+          requiresAuth: true,
+          data: { comment: pendingComment },
+        },
+        (res) => {
+          if (!res.ok) {
+            showSimpleError(getApiResponseErrorMessage(res))
+          }
+        },
+      )
+    }
     // eslint-disable-next-line @eslint-react/exhaustive-deps -- intentionally re-initialize form only when switching applications
   }, [application?.applicationId])
 
   const [loading, setLoading] = useState(false)
 
-  const [debouncedComment] = useDebouncedValue(form.values.comment, 1000)
+  const [debouncedComment] = useDebouncedValue(form.values.comment, 500)
 
   useEffect(() => {
     if (form.values.applicationId !== application.applicationId) {

--- a/server/src/main/resources/db/changelog/manual/seed_dev_test_data.sql
+++ b/server/src/main/resources/db/changelog/manual/seed_dev_test_data.sql
@@ -2194,3 +2194,42 @@ VALUES
      NULL, 'Room 01.07.023, Boltzmannstr. 3', NULL)
 ON CONFLICT DO NOTHING;
 
+-- ============================================================================
+-- 42. E2E COVERAGE GAP TEST DATA — ISSUE #754 COMMENT AUTO-SAVE
+-- ----------------------------------------------------------------------------
+-- Two NOT_ASSESSED applications dedicated to the application-review-comment
+-- regression test. Using students 2 and 3 (which only have older REJECTED /
+-- ACCEPTED apps in this seed) gives us deterministically unique sidebar rows
+-- for the supervisor on topic 1.
+-- ============================================================================
+INSERT INTO applications (application_id, user_id, topic_id, thesis_title, thesis_type, motivation,
+                          state, reject_reason, desired_start_date, comment, created_at, reviewed_at,
+                          research_group_id)
+VALUES
+    ('00000000-0000-4000-c000-000000000040'::UUID,
+     (SELECT user_id FROM users WHERE university_id = 'student2'),
+     '00000000-0000-4000-b000-000000000001'::UUID,
+     NULL, 'MASTER',
+     'Issue #754 regression: applicant A for comment auto-save test.',
+     'NOT_ASSESSED', NULL,
+     NOW() + INTERVAL '30 days', '',
+     NOW() - INTERVAL '2 days', NULL,
+     '00000000-0000-4000-a000-000000000001'::UUID),
+
+    ('00000000-0000-4000-c000-000000000041'::UUID,
+     (SELECT user_id FROM users WHERE university_id = 'student3'),
+     '00000000-0000-4000-b000-000000000001'::UUID,
+     NULL, 'MASTER',
+     'Issue #754 regression: applicant B for comment auto-save test.',
+     'NOT_ASSESSED', NULL,
+     NOW() + INTERVAL '30 days', '',
+     NOW() - INTERVAL '1 day', NULL,
+     '00000000-0000-4000-a000-000000000001'::UUID)
+ON CONFLICT DO NOTHING;
+
+UPDATE applications SET consent_timestamp = created_at
+WHERE application_id IN (
+    '00000000-0000-4000-c000-000000000040'::UUID,
+    '00000000-0000-4000-c000-000000000041'::UUID
+) AND consent_timestamp IS NULL;
+


### PR DESCRIPTION
## Summary

Fixes [#754](https://github.com/ls1intum/thesis-management/issues/754) — comments typed into an applicant's review form were silently lost when the reviewer clicked another applicant in the sidebar before the auto-save debounce fired.

### Root cause

`ApplicationReviewForm` debounced the comment auto-save by 1 s. When the user switched applicants inside that window:

1. `useLayoutEffect` re-ran (the applicationId changed).
2. It called `form.setInitialValues(...)` then `form.reset()`, replacing `form.values.comment` with the new applicant's value.
3. The debouncer (which tracks `form.values.comment`) cancelled its pending timer — the typed text never made it to the `PUT`.

The workaround in the issue (click outside the textbox first) worked only because waiting after blur gave the debounce time to fire.

### Fix

`ApplicationReviewForm.tsx`:

- Track the latest typed comment and the most recent saved baseline in refs, kept in sync with `useEffect`.
- In the `useLayoutEffect` that handles application switching, add a cleanup that flushes any pending comment edit for the application being left, with two short-circuits to avoid redundant PUTs:
  - skip if pending text matches the closure baseline (no edits)
  - skip if it matches the latest saved value (debounced save already persisted it)
- The cleanup deliberately does **not** call `onUpdate`, so a late response can't yank the user back to the previous applicant.
- Tighten the debounce from 1000 ms → 500 ms so "Saved!" feedback appears sooner during normal typing — safe because the cleanup now protects against the previous race.

### Tests

- **Vitest** (`ApplicationReviewForm.test.tsx`): three regression specs covering the fast-switch flush, the no-op short-circuit, and the unchanged debounced-save path.
- **Playwright** (`application-comment-autosave.spec.ts`): logs in as supervisor, types a unique comment, immediately clicks another applicant inside the 500 ms window, hard-reloads the original applicant, and asserts the textarea reflects the server-persisted value.
- **Seed data** (`seed_dev_test_data.sql` §42): two dedicated NOT_ASSESSED applications (`c000-…-0040` Student2 and `c000-…-0041` Student3) on the supervisor's topic 1. Students 2 and 3 don't otherwise have NOT_ASSESSED apps in the seed, so the sidebar regex matches one row each, deterministically. Doesn't collide with apps 4/5 (`application-review-workflow`) or 12/13 (`interview-process-workflow`).

## Test plan

- [x] `cd client && pnpm test` — 67 vitest + 26 node tests pass
- [x] `cd client && pnpm exec tsc --noEmit` — clean
- [x] `cd client && pnpm lint` — clean
- [x] `cd server && ./gradlew test` — 805/805 pass
- [x] `cd server && ./gradlew spotlessCheck` — clean
- [x] `./execute-e2e-local.sh` — full Playwright suite, 226/226 pass (including the new spec)
- [x] Manual: reproduce in the browser — type a comment on applicant A, immediately click applicant B, return to A; comment is persisted (was lost before the fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed issue #754 where application comments were inadvertently lost when switching between applicants before the auto-save cycle completed.
  * Accelerated comment auto-save speed from 1000 milliseconds to 500 milliseconds for faster persistence and user feedback.
* **Tests**
  * Added comprehensive end-to-end and unit regression tests to verify comment auto-save behavior and integrity when switching between applicants.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ls1intum/thesis-management/pull/1047)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->