### PR TITLE
Hide topics with past application deadlines and add EXPIRED state

### DIFF
--- a/client/src/components/TopicsTable/TopicsTable.tsx
+++ b/client/src/components/TopicsTable/TopicsTable.tsx
@@ -44,6 +44,8 @@ const TopicsTable = (props: ITopicOverviewsTableProps) => {
         return 'red'
       case TopicState.DRAFT:
         return 'yellow'
+      case TopicState.EXPIRED:
+        return 'orange'
       default:
         return 'gray'
     }

--- a/client/src/pages/LandingPage/LandingPage.tsx
+++ b/client/src/pages/LandingPage/LandingPage.tsx
@@ -182,7 +182,7 @@ const LandingPage = () => {
                         justify='center'
                         onClick={(e) => e.stopPropagation()}
                       >
-                        {topic.state !== TopicState.CLOSED && (
+                        {topic.state === TopicState.OPEN && (
                           <Button
                             component={Link}
                             to={`/submit-application/${topic.topicId}`}

--- a/client/src/pages/LandingPage/components/TopicCardGrid/TopicCard/TopicCard.tsx
+++ b/client/src/pages/LandingPage/components/TopicCardGrid/TopicCard/TopicCard.tsx
@@ -130,13 +130,13 @@ const TopicCard = ({ topic, setOpenTopic }: ITopicCardProps) => {
             <DownloadSimple />
           </Button>
         </Group>
-      ) : 'state' in topic && topic.state === TopicState.EXPIRED ? (
-        <Button fullWidth mt='md' component={Link} to={`/topics/${topicId}`}>
-          More Information
-        </Button>
-      ) : (
+      ) : 'state' in topic && topic.state === TopicState.OPEN ? (
         <Button fullWidth mt='md' component={Link} to={`/submit-application/${topicId}`}>
           Apply
+        </Button>
+      ) : (
+        <Button fullWidth mt='md' component={Link} to={`/topics/${topicId}`}>
+          More Information
         </Button>
       )}
     </Card>

--- a/client/src/pages/LandingPage/components/TopicCardGrid/TopicCard/TopicCard.tsx
+++ b/client/src/pages/LandingPage/components/TopicCardGrid/TopicCard/TopicCard.tsx
@@ -1,5 +1,6 @@
 import { Card, Flex, Text, Group, Stack, Button, Tooltip, Anchor, Box } from '@mantine/core'
 import type { ITopicOverview } from '../../../../../requests/responses/topic'
+import { TopicState } from '../../../../../requests/responses/topic'
 import { useHover, useMediaQuery } from '@mantine/hooks'
 import { DownloadSimple, Users } from '@phosphor-icons/react'
 import AvatarUserList from '../../../../../components/AvatarUserList/AvatarUserList'
@@ -129,9 +130,7 @@ const TopicCard = ({ topic, setOpenTopic }: ITopicCardProps) => {
             <DownloadSimple />
           </Button>
         </Group>
-      ) : 'applicationDeadline' in topic &&
-        topic.applicationDeadline &&
-        new Date(topic.applicationDeadline) < new Date() ? (
+      ) : 'state' in topic && topic.state === TopicState.EXPIRED ? (
         <Button fullWidth mt='md' component={Link} to={`/topics/${topicId}`}>
           More Information
         </Button>

--- a/client/src/pages/ReplaceApplicationPage/components/SelectTopicStep/components/CollapsibleTopicElement.tsx
+++ b/client/src/pages/ReplaceApplicationPage/components/SelectTopicStep/components/CollapsibleTopicElement.tsx
@@ -12,6 +12,7 @@ import {
   Loader,
 } from '@mantine/core'
 import type { ITopicOverview, ITopic } from '../../../../../requests/responses/topic'
+import { TopicState } from '../../../../../requests/responses/topic'
 import ThesisTypeBadge from '../../../../LandingPage/components/ThesisTypBadge/ThesisTypBadge'
 import type { IPublishedThesis } from '../../../../../requests/responses/thesis'
 import { useHover } from '@mantine/hooks'
@@ -34,10 +35,7 @@ const CollapsibleTopicElement = ({ topic, onApply }: ICollapsibleTopicElementPro
   const isTopicOverview = 'topicId' in topic
   const fullTopic = useTopic(isTopicOverview && expanded ? topic.topicId : undefined)
 
-  const deadlinePassed =
-    !!fullTopic &&
-    !!fullTopic.applicationDeadline &&
-    new Date(fullTopic.applicationDeadline) < new Date()
+  const deadlinePassed = !!fullTopic && fullTopic.state === TopicState.EXPIRED
 
   return (
     <Card

--- a/client/src/pages/ReplaceApplicationPage/components/SelectTopicStep/components/CollapsibleTopicElement.tsx
+++ b/client/src/pages/ReplaceApplicationPage/components/SelectTopicStep/components/CollapsibleTopicElement.tsx
@@ -35,7 +35,7 @@ const CollapsibleTopicElement = ({ topic, onApply }: ICollapsibleTopicElementPro
   const isTopicOverview = 'topicId' in topic
   const fullTopic = useTopic(isTopicOverview && expanded ? topic.topicId : undefined)
 
-  const canApply = !fullTopic || fullTopic.state === TopicState.OPEN
+  const canApply = !!fullTopic && fullTopic.state === TopicState.OPEN
 
   return (
     <Card

--- a/client/src/pages/ReplaceApplicationPage/components/SelectTopicStep/components/CollapsibleTopicElement.tsx
+++ b/client/src/pages/ReplaceApplicationPage/components/SelectTopicStep/components/CollapsibleTopicElement.tsx
@@ -35,7 +35,7 @@ const CollapsibleTopicElement = ({ topic, onApply }: ICollapsibleTopicElementPro
   const isTopicOverview = 'topicId' in topic
   const fullTopic = useTopic(isTopicOverview && expanded ? topic.topicId : undefined)
 
-  const deadlinePassed = !!fullTopic && fullTopic.state === TopicState.EXPIRED
+  const canApply = !fullTopic || fullTopic.state === TopicState.OPEN
 
   return (
     <Card
@@ -155,13 +155,13 @@ const CollapsibleTopicElement = ({ topic, onApply }: ICollapsibleTopicElementPro
                   // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- useTopic may return `false` (error sentinel) which must also map to undefined
                   onClick={() => onApply(fullTopic || undefined)}
                   fullWidth
-                  disabled={!fullTopic || deadlinePassed}
+                  disabled={!canApply}
                 >
                   Apply
                 </Button>
-                {deadlinePassed && (
+                {!canApply && !!fullTopic && (
                   <Text size='xs' c='dimmed' ta='center'>
-                    Application deadline has passed.
+                    Applications are not open for this topic.
                   </Text>
                 )}
               </Stack>

--- a/client/src/pages/TopicPage/TopicPage.tsx
+++ b/client/src/pages/TopicPage/TopicPage.tsx
@@ -11,6 +11,7 @@ import ApplicationsTable from '../../components/ApplicationsTable/ApplicationsTa
 import { NotePencil } from '@phosphor-icons/react'
 import TopicAdittionalInformationCard from './components/TopicAdittionalInformationCard'
 import TopicInformationCard from './components/TopicInformationCard'
+import { TopicState } from '../../requests/responses/topic'
 
 const TopicPage = () => {
   const { topicId } = useParams<{ topicId: string }>()
@@ -42,8 +43,7 @@ const TopicPage = () => {
     return isExaminer || isSupervisor
   }
 
-  const deadlinePassed =
-    !!topic.applicationDeadline && new Date(topic.applicationDeadline) < new Date()
+  const deadlinePassed = topic.state === TopicState.EXPIRED || topic.state === TopicState.CLOSED
 
   return (
     <Stack gap={'2rem'}>

--- a/client/src/pages/TopicPage/TopicPage.tsx
+++ b/client/src/pages/TopicPage/TopicPage.tsx
@@ -43,7 +43,7 @@ const TopicPage = () => {
     return isExaminer || isSupervisor
   }
 
-  const deadlinePassed = topic.state === TopicState.EXPIRED || topic.state === TopicState.CLOSED
+  const canApply = topic.state === TopicState.OPEN
 
   return (
     <Stack gap={'2rem'}>
@@ -51,11 +51,7 @@ const TopicPage = () => {
         <Title>{topic.title}</Title>
         {!managementAccess && !checkIfUserIsExaminerOrSupervisor() && (
           <Stack gap='xs' mr='auto'>
-            {deadlinePassed ? (
-              <Button leftSection={<NotePencil size={24} />} size='md' disabled>
-                Apply Now
-              </Button>
-            ) : (
+            {canApply ? (
               <Button
                 component={Link}
                 to={`/submit-application/${topic.topicId}`}
@@ -64,10 +60,14 @@ const TopicPage = () => {
               >
                 Apply Now
               </Button>
+            ) : (
+              <Button leftSection={<NotePencil size={24} />} size='md' disabled>
+                Apply Now
+              </Button>
             )}
-            {deadlinePassed && (
+            {!canApply && (
               <Text size='sm' c='dimmed'>
-                Application deadline has passed.
+                Applications are not open for this topic.
               </Text>
             )}
           </Stack>

--- a/client/src/requests/responses/topic.ts
+++ b/client/src/requests/responses/topic.ts
@@ -5,6 +5,7 @@ export enum TopicState {
   OPEN = 'OPEN',
   DRAFT = 'DRAFT',
   CLOSED = 'CLOSED',
+  EXPIRED = 'EXPIRED',
 }
 
 export interface ITopicOverview {

--- a/client/src/utils/format.ts
+++ b/client/src/utils/format.ts
@@ -130,6 +130,7 @@ export function formatTopicState(state: TopicState) {
     [TopicState.OPEN]: 'Open',
     [TopicState.DRAFT]: 'Draft',
     [TopicState.CLOSED]: 'Closed',
+    [TopicState.EXPIRED]: 'Expired',
   }
 
   return stateMap[state]

--- a/server/src/main/java/de/tum/cit/aet/thesis/constants/TopicState.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/constants/TopicState.java
@@ -8,7 +8,8 @@ import lombok.Getter;
 public enum TopicState {
 	OPEN("OPEN"),
 	CLOSED("WRITING"),
-	DRAFT("DRAFT");
+	DRAFT("DRAFT"),
+	EXPIRED("EXPIRED");
 
 	private final String value;
 }

--- a/server/src/main/java/de/tum/cit/aet/thesis/cron/AutomaticRejects.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/cron/AutomaticRejects.java
@@ -62,7 +62,7 @@ public class AutomaticRejects {
 		for (ResearchGroupSettings settings : enabledResearchGroups) {
 			Map<User, List<ApplicationRejectObject>> reminderApplicationsByUser = new HashMap<>();
 
-			List<Topic> openTopics = topicService.getOpenFromResearchGroup(settings.getResearchGroupId());
+			List<Topic> openTopics = topicService.getPublishedFromResearchGroup(settings.getResearchGroupId());
 			for (Topic topic : openTopics) {
 				Instant referenceDate;
 

--- a/server/src/main/java/de/tum/cit/aet/thesis/cron/AutomaticRejects.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/cron/AutomaticRejects.java
@@ -62,8 +62,8 @@ public class AutomaticRejects {
 		for (ResearchGroupSettings settings : enabledResearchGroups) {
 			Map<User, List<ApplicationRejectObject>> reminderApplicationsByUser = new HashMap<>();
 
-			List<Topic> openTopics = topicService.getPublishedFromResearchGroup(settings.getResearchGroupId());
-			for (Topic topic : openTopics) {
+			List<Topic> publishedTopics = topicService.getPublishedFromResearchGroup(settings.getResearchGroupId());
+			for (Topic topic : publishedTopics) {
 				Instant referenceDate;
 
 				if (topic.getApplicationDeadline() != null) {

--- a/server/src/main/java/de/tum/cit/aet/thesis/entity/Topic.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/entity/Topic.java
@@ -129,6 +129,8 @@ public class Topic {
 			return TopicState.CLOSED;
 		} else if (this.publishedAt == null) {
 			return TopicState.DRAFT;
+		} else if (this.applicationDeadline != null && this.applicationDeadline.isBefore(Instant.now())) {
+			return TopicState.EXPIRED;
 		} else {
 			return TopicState.OPEN;
 		}

--- a/server/src/main/java/de/tum/cit/aet/thesis/repository/TopicRepository.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/repository/TopicRepository.java
@@ -20,9 +20,10 @@ public interface TopicRepository extends JpaRepository<Topic, UUID> {
 					(
 						CAST(:states AS TEXT[]) IS NULL
 						OR (
-							('CLOSED' = ANY(CAST(:states AS TEXT[])) AND t.closed_at IS NOT NULL)
-						OR ('DRAFT'  = ANY(CAST(:states AS TEXT[])) AND t.closed_at IS NULL AND t.published_at IS NULL)
-						OR ('OPEN'   = ANY(CAST(:states AS TEXT[])) AND t.closed_at IS NULL AND t.published_at IS NOT NULL)
+							('CLOSED'  = ANY(CAST(:states AS TEXT[])) AND t.closed_at IS NOT NULL)
+						OR ('DRAFT'   = ANY(CAST(:states AS TEXT[])) AND t.closed_at IS NULL AND t.published_at IS NULL)
+						OR ('OPEN'    = ANY(CAST(:states AS TEXT[])) AND t.closed_at IS NULL AND t.published_at IS NOT NULL AND (t.application_deadline IS NULL OR t.application_deadline >= NOW()))
+						OR ('EXPIRED' = ANY(CAST(:states AS TEXT[])) AND t.closed_at IS NULL AND t.published_at IS NOT NULL AND t.application_deadline IS NOT NULL AND t.application_deadline < NOW())
 						)
 					)
 			""", nativeQuery = true)
@@ -37,6 +38,7 @@ public interface TopicRepository extends JpaRepository<Topic, UUID> {
 	@Query("SELECT DISTINCT t FROM Topic t " +
 			"WHERE (:searchQuery IS NULL OR LOWER(t.title) LIKE :searchQuery) " +
 			"AND t.closedAt IS NULL " +
+			"AND (t.applicationDeadline IS NULL OR t.applicationDeadline >= CURRENT_TIMESTAMP) " +
 			"AND ( :userId IS NULL " +
 			"      OR ( :excludeSupervised = true " +
 			"           AND EXISTS (SELECT 1 FROM TopicRole r " +
@@ -57,7 +59,18 @@ public interface TopicRepository extends JpaRepository<Topic, UUID> {
 				SELECT COUNT(*)
 				FROM Topic t
 				WHERE t.closedAt IS NULL
+				AND (t.applicationDeadline IS NULL OR t.applicationDeadline >= CURRENT_TIMESTAMP)
 				AND (:researchGroupId IS NULL OR t.researchGroup.id = :researchGroupId)
 			""")
 	long countOpenTopics(@Param("researchGroupId") UUID researchGroupId);
+
+	@Query(value = """
+			SELECT t.* FROM topics t
+			WHERE t.closed_at IS NULL AND t.published_at IS NOT NULL
+			AND (:researchGroupId IS NULL OR t.research_group_id = :researchGroupId)
+			""", nativeQuery = true)
+	Page<Topic> findPublishedTopics(
+			@Param("researchGroupId") UUID researchGroupId,
+			Pageable page
+	);
 }

--- a/server/src/main/java/de/tum/cit/aet/thesis/repository/TopicRepository.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/repository/TopicRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
@@ -38,6 +39,7 @@ public interface TopicRepository extends JpaRepository<Topic, UUID> {
 	@Query("SELECT DISTINCT t FROM Topic t " +
 			"WHERE (:searchQuery IS NULL OR LOWER(t.title) LIKE :searchQuery) " +
 			"AND t.closedAt IS NULL " +
+			"AND t.publishedAt IS NOT NULL " +
 			"AND (t.applicationDeadline IS NULL OR t.applicationDeadline >= CURRENT_TIMESTAMP) " +
 			"AND ( :userId IS NULL " +
 			"      OR ( :excludeSupervised = true " +
@@ -59,18 +61,18 @@ public interface TopicRepository extends JpaRepository<Topic, UUID> {
 				SELECT COUNT(*)
 				FROM Topic t
 				WHERE t.closedAt IS NULL
+				AND t.publishedAt IS NOT NULL
 				AND (t.applicationDeadline IS NULL OR t.applicationDeadline >= CURRENT_TIMESTAMP)
 				AND (:researchGroupId IS NULL OR t.researchGroup.id = :researchGroupId)
 			""")
 	long countOpenTopics(@Param("researchGroupId") UUID researchGroupId);
 
-	@Query(value = """
-			SELECT t.* FROM topics t
-			WHERE t.closed_at IS NULL AND t.published_at IS NOT NULL
-			AND (:researchGroupId IS NULL OR t.research_group_id = :researchGroupId)
-			""", nativeQuery = true)
-	Page<Topic> findPublishedTopics(
-			@Param("researchGroupId") UUID researchGroupId,
-			Pageable page
+	@Query("""
+			SELECT t FROM Topic t
+			WHERE t.closedAt IS NULL AND t.publishedAt IS NOT NULL
+			AND (:researchGroupId IS NULL OR t.researchGroup.id = :researchGroupId)
+			""")
+	List<Topic> findPublishedTopics(
+			@Param("researchGroupId") UUID researchGroupId
 	);
 }

--- a/server/src/main/java/de/tum/cit/aet/thesis/service/ApplicationService.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/service/ApplicationService.java
@@ -203,6 +203,10 @@ public class ApplicationService {
 		Topic topic = topicId == null ? null : topicService.findById(topicId);
 		Instant now = Instant.now(clock);
 
+		if (topic != null && topic.getPublishedAt() == null) {
+			throw new ResourceInvalidParametersException("This topic is not open for applications.");
+		}
+
 		if (topic != null && topic.getClosedAt() != null) {
 			throw new ResourceInvalidParametersException("This topic is already closed. You cannot submit new applications for it.");
 		}

--- a/server/src/main/java/de/tum/cit/aet/thesis/service/TopicService.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/service/TopicService.java
@@ -112,7 +112,11 @@ public class TopicService {
 
 
 		if (states != null && Arrays.stream(states).anyMatch(s -> s.equals(TopicState.CLOSED.name()) || s.equals(TopicState.DRAFT.name()) || s.equals(TopicState.EXPIRED.name()))) {
-			currentUserProvider().assertCanAccessResearchGroup(researchGroup);
+			CurrentUserProvider cup = currentUserProvider();
+			if (!cup.isAdmin() && !cup.getUser().hasAnyGroup("supervisor", "advisor")) {
+				throw new org.springframework.security.access.AccessDeniedException("Only privileged users can query non-OPEN topic states.");
+			}
+			cup.assertCanAccessResearchGroup(researchGroup);
 		}
 		String[] statesFilter = (states != null && states.length > 0) ? states : new String[] { TopicState.OPEN.name() };
 
@@ -179,10 +183,7 @@ public class TopicService {
 	}
 
 	public List<Topic> getPublishedFromResearchGroup(UUID researchGroupId) {
-		return topicRepository.findPublishedTopics(
-				researchGroupId,
-				PageRequest.of(0, Integer.MAX_VALUE, Sort.unsorted())
-		).toList();
+		return topicRepository.findPublishedTopics(researchGroupId);
 	}
 
 	// TODO: we should avoid using @Transactional because it can lead to performance issue and concurrency problems

--- a/server/src/main/java/de/tum/cit/aet/thesis/service/TopicService.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/service/TopicService.java
@@ -111,7 +111,7 @@ public class TopicService {
 		String[] typesFilter = types == null || types.length == 0 ? null : types;
 
 
-		if (states != null && Arrays.stream(states).anyMatch(s -> s.equals(TopicState.CLOSED.name()) || s.equals(TopicState.DRAFT.name()))) {
+		if (states != null && Arrays.stream(states).anyMatch(s -> s.equals(TopicState.CLOSED.name()) || s.equals(TopicState.DRAFT.name()) || s.equals(TopicState.EXPIRED.name()))) {
 			currentUserProvider().assertCanAccessResearchGroup(researchGroup);
 		}
 		String[] statesFilter = (states != null && states.length > 0) ? states : new String[] { TopicState.OPEN.name() };
@@ -174,6 +174,13 @@ public class TopicService {
 				null,
 				new String[] { TopicState.OPEN.name() },
 				null,
+				PageRequest.of(0, Integer.MAX_VALUE, Sort.unsorted())
+		).toList();
+	}
+
+	public List<Topic> getPublishedFromResearchGroup(UUID researchGroupId) {
+		return topicRepository.findPublishedTopics(
+				researchGroupId,
 				PageRequest.of(0, Integer.MAX_VALUE, Sort.unsorted())
 		).toList();
 	}

--- a/server/src/test/java/de/tum/cit/aet/thesis/mock/EntityMockFactory.java
+++ b/server/src/test/java/de/tum/cit/aet/thesis/mock/EntityMockFactory.java
@@ -13,6 +13,7 @@ import de.tum.cit.aet.thesis.entity.UserGroup;
 import de.tum.cit.aet.thesis.entity.key.ThesisRoleId;
 import de.tum.cit.aet.thesis.entity.key.UserGroupId;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -92,6 +93,9 @@ public class EntityMockFactory {
 		topic.setTitle(title);
 		topic.setRoles(new ArrayList<>());
 		topic.setResearchGroup(researchGroup);
+		topic.setCreatedAt(Instant.now());
+		topic.setUpdatedAt(Instant.now());
+		topic.setPublishedAt(Instant.now());
 
 		return topic;
 	}


### PR DESCRIPTION
## Summary

- Topics with a past `applicationDeadline` are excluded from open topic listings, counts, and interview topic selection
- New `EXPIRED` topic state derived dynamically from `applicationDeadline` in `getTopicState()` — no database column or cronjob needed
- Apply buttons are shown only for `OPEN` topics across all views (landing page, topic detail, topic cards, application flow)
- Manage topics page shows an orange "Expired" badge and allows supervisors to still edit expired topics (e.g. to extend the deadline)
- Auto-reject cron uses a new `findPublishedTopics` query so it still processes applications on expired topics
- Draft topics are excluded from `countOpenTopics` and `findOpenTopicsForUserByRoles` queries (`publishedAt IS NOT NULL`)
- Non-OPEN state queries (DRAFT/CLOSED/EXPIRED) are restricted to privileged roles (admin/supervisor/advisor) — students cannot browse drafts
- Server-side `createApplication` rejects applications for draft topics (in addition to closed and deadline-passed)
- `findPublishedTopics` converted from native `Page` query to JPQL `List` query, removing the `Integer.MAX_VALUE` pagination workaround

## Test Plan

- [ ] Verify topics with past deadlines do not appear in the open topics list on the homepage
- [ ] Verify topics with past deadlines show "Expired" (orange) badge on the manage topics page
- [ ] Verify the Apply button is disabled on the topic detail page for expired topics
- [ ] Verify the Apply button is disabled for DRAFT and CLOSED topics too
- [ ] Verify supervisors can still edit expired topics (e.g. extend deadline)
- [ ] Verify the auto-reject cron still processes applications on expired topics
- [ ] Verify topics without a deadline are unaffected and still show as OPEN
- [ ] Verify students cannot query DRAFT/CLOSED/EXPIRED states via the topics API
- [ ] Run `./gradlew test` — all 864 tests pass
- [ ] Run `pnpm exec tsc --noEmit` — no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Topics can now be marked as Expired and show an orange "Expired" badge.
* **Behavior Changes**
  * The "Apply" button and application availability are shown only for topics that are Open.
  * Messages and disabled-state text now indicate "Applications are not open for this topic." instead of deadline-based wording.
* **Back-end Alignment**
  * Automatic processing and validations now align topic availability with the published/expired status.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ls1intum/thesis-management/pull/1089?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->