### PR TITLE
Enable server checkstyle in CI and fix pre-existing violations

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -28,6 +28,12 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x ./server/gradlew
 
+      # Enforce code style before the (slower) test run so violations fail fast
+      - name: Run server checkstyle
+        working-directory: ./server
+        run: |
+          ./gradlew checkstyleMain checkstyleTest
+
       # Run tests with coverage for server
       - name: Run server tests with coverage
         working-directory: ./server

--- a/server/src/main/java/de/tum/cit/aet/thesis/repository/TopicRepository.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/repository/TopicRepository.java
@@ -23,8 +23,10 @@ public interface TopicRepository extends JpaRepository<Topic, UUID> {
 						OR (
 							('CLOSED'  = ANY(CAST(:states AS TEXT[])) AND t.closed_at IS NOT NULL)
 						OR ('DRAFT'   = ANY(CAST(:states AS TEXT[])) AND t.closed_at IS NULL AND t.published_at IS NULL)
-						OR ('OPEN'    = ANY(CAST(:states AS TEXT[])) AND t.closed_at IS NULL AND t.published_at IS NOT NULL AND (t.application_deadline IS NULL OR t.application_deadline >= NOW()))
-						OR ('EXPIRED' = ANY(CAST(:states AS TEXT[])) AND t.closed_at IS NULL AND t.published_at IS NOT NULL AND t.application_deadline IS NOT NULL AND t.application_deadline < NOW())
+						OR ('OPEN'    = ANY(CAST(:states AS TEXT[])) AND t.closed_at IS NULL AND t.published_at IS NOT NULL
+							AND (t.application_deadline IS NULL OR t.application_deadline >= NOW()))
+						OR ('EXPIRED' = ANY(CAST(:states AS TEXT[])) AND t.closed_at IS NULL AND t.published_at IS NOT NULL
+							AND t.application_deadline IS NOT NULL AND t.application_deadline < NOW())
 						)
 					)
 			""", nativeQuery = true)

--- a/server/src/main/java/de/tum/cit/aet/thesis/service/TopicService.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/service/TopicService.java
@@ -182,6 +182,12 @@ public class TopicService {
 		).toList();
 	}
 
+	/**
+	 * Returns all published topics that belong to the given research group.
+	 *
+	 * @param researchGroupId the identifier of the research group
+	 * @return the published topics of the research group
+	 */
 	public List<Topic> getPublishedFromResearchGroup(UUID researchGroupId) {
 		return topicRepository.findPublishedTopics(researchGroupId);
 	}


### PR DESCRIPTION
## Summary

Enables **Checkstyle in CI** for the server and fixes the violations that had silently accumulated because it was never enforced.

## Why

The Checkstyle config (`server/config/checkstyle/checkstyle.xml`, `maxWarnings = 0`) existed but **nothing ran it in CI**:
- `server.Dockerfile` builds with `-x checkstyleMain -x checkstyleTest`
- `run_tests.yml` only ran `./gradlew test` (which doesn't trigger checkstyle)

As a result, `./gradlew checkstyleMain` on `develop` currently **fails** with 3 violations (verified on a clean `develop` checkout).

## Changes

**Fix existing violations** (all introduced by #1089, behavior-preserving):
- `TopicRepository.searchTopics` — two native-query lines exceeded the 200-char `LineLength` limit (Checkstyle counts tabs at width 8). Wrapped the `OPEN`/`EXPIRED` conditions onto continuation lines; the SQL is unchanged (newline = whitespace).
- `TopicService.getPublishedFromResearchGroup` — added the required public-method Javadoc (`@param`/`@return`, as `JavadocMethod` mandates).

**Enforce going forward:**
- Added a `Run server checkstyle` step (`./gradlew checkstyleMain checkstyleTest`) to `run_tests.yml`, before the test run so style issues fail fast.

## Verification

- `./gradlew checkstyleMain checkstyleTest` → **BUILD SUCCESSFUL**
- `./gradlew compileJava` → succeeds
- CI runs the full test suite on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added code style enforcement checks to the build pipeline to catch style violations early.

* **Documentation**
  * Improved method documentation with additional Javadoc comments.

* **Style**
  * Reformatted query code for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->