### PR TITLE
Fix white-screen crash when searching cleared application filters

### DIFF
--- a/client/e2e/application/applications.spec.ts
+++ b/client/e2e/application/applications.spec.ts
@@ -68,6 +68,45 @@ test.describe('Applications - Supervisor review', () => {
     // Supervisor should NOT see Submit Application link (not a student)
     await expect(page.getByRole('link', { name: 'Submit Application' })).toBeHidden()
   })
+
+  // Regression for #1136: typing into the search field after deselecting the
+  // default filters used to throw "e.currentTarget is null" because the
+  // setState updater read currentTarget after the browser had released the
+  // synthetic event. The page would white-screen until reload.
+  test('search field does not crash when filters are cleared (#1136)', async ({ page }) => {
+    const pageErrors: Error[] = []
+    page.on('pageerror', (error) => pageErrors.push(error))
+
+    await navigateTo(page, '/applications')
+
+    const searchInput = page.getByPlaceholder(/search applications/i)
+    await expect(searchInput).toBeVisible({ timeout: 15_000 })
+
+    // Remove every selected pill from the topic / type / states MultiSelects.
+    // The supervisor lands on the page with a default state ("Not Assessed")
+    // and assigned-topic pills already populated.
+    const removeButtons = page.locator(
+      '.mantine-MultiSelect-root .mantine-Pill-remove, .mantine-MultiSelect-root [data-pill-remove]',
+    )
+    // Loop with a re-query each iteration: each click triggers a re-render so
+    // stale handles would detach.
+    for (let safety = 0; safety < 50; safety++) {
+      const remaining = await removeButtons.count()
+      if (remaining === 0) break
+      await removeButtons.first().click()
+    }
+    await expect(removeButtons).toHaveCount(0)
+
+    // Type into the search input — this is what crashed the app pre-fix.
+    await searchInput.click()
+    await searchInput.fill('alice')
+    await expect(searchInput).toHaveValue('alice')
+
+    // The sidebar (and search input) must still be mounted — i.e. no white
+    // screen — and no unhandled exception should have reached the page.
+    await expect(searchInput).toBeVisible()
+    expect(pageErrors, pageErrors.map((e) => e.message).join('\n')).toHaveLength(0)
+  })
 })
 
 test.describe('Applications - Examiner review', () => {

--- a/client/src/core/application/components/ApplicationsFilters/ApplicationsFilters.tsx
+++ b/client/src/core/application/components/ApplicationsFilters/ApplicationsFilters.tsx
@@ -23,7 +23,11 @@ const ApplicationsFilters = (props: IApplicationsFiltersProps) => {
           leftSection={<MagnifyingGlass size={16} />}
           value={filters.search ?? ''}
           onChange={(e) => {
-            setFilters((prev) => ({ ...prev, search: e.currentTarget.value }))
+            // Capture value synchronously — currentTarget is null once the
+            // browser releases the event after the handler returns, and the
+            // setState updater below runs in a later render tick.
+            const search = e.currentTarget.value
+            setFilters((prev) => ({ ...prev, search }))
           }}
         />
       </Grid.Col>
@@ -113,12 +117,13 @@ const ApplicationsFilters = (props: IApplicationsFiltersProps) => {
           label='Include suggested topics'
           description='Show applications without a specific topic (the student proposed their own thesis title)'
           checked={filters.includeSuggestedTopics !== false}
-          onChange={(e) =>
+          onChange={(e) => {
+            const includeSuggestedTopics = e.currentTarget.checked
             setFilters((prev) => ({
               ...prev,
-              includeSuggestedTopics: e.currentTarget.checked,
+              includeSuggestedTopics,
             }))
-          }
+          }}
         />
       </Grid.Col>
     </Grid>


### PR DESCRIPTION
## Summary
- Search input in the Review Applications view passed a setState updater that read `e.currentTarget.value` lazily; React batches the updater, so by the time it ran the browser had already nulled the synthetic event's `currentTarget`, throwing `TypeError` and white-screening the page.
- Capture the value synchronously inside the handler. Same fix applied to the "Include suggested topics" Switch (`e.currentTarget.checked`), which had the identical shape.
- Adds a Playwright regression test that follows the original repro — clear all multi-select filters, type into the search box — and asserts the input stays mounted with no uncaught `pageerror`.

## Test plan
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm exec eslint src/core/application/components/ApplicationsFilters/ApplicationsFilters.tsx`
- [x] `pnpm exec vitest run src/core/application/components/ApplicationsFilters/ApplicationsFilters.test.tsx` — 3/3 pass
- [x] `./execute-e2e-local.sh -g "#1136"` — passes with the fix
- [x] Reverted the source fix locally and re-ran the same e2e — confirmed it fails (input element vanishes from DOM after `fill`), then re-applied the fix

Fixes #1136

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where searching on the Applications page could cause the page to crash after filters were cleared.
  * Improved stability of the search and filter controls so they continue working normally after removing selected filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->