### PR TITLE
Preserve table pagination on back-nav and enable new-tab row clicks

### DIFF
--- a/client/src/core/admin/pages/DashboardPage/components/MyTasksSection/MyTasksSection.tsx
+++ b/client/src/core/admin/pages/DashboardPage/components/MyTasksSection/MyTasksSection.tsx
@@ -40,8 +40,10 @@ const MyTasksSection = () => {
     return null
   }
 
-  const redirectTask = (task: ITask) => {
-    if (task.link.startsWith('http')) {
+  const redirectTask = (task: ITask, openInNewTab = false) => {
+    if (openInNewTab) {
+      window.open(task.link, '_blank', 'noopener,noreferrer')
+    } else if (task.link.startsWith('http')) {
       window.location.replace(task.link)
     } else {
       void navigate(task.link)
@@ -79,7 +81,17 @@ const MyTasksSection = () => {
             ),
           },
         ]}
-        onRowClick={({ record }) => redirectTask(record)}
+        onRowClick={({ record, event }) =>
+          redirectTask(record, event.metaKey || event.ctrlKey || event.shiftKey)
+        }
+        customRowAttributes={(record) => ({
+          onAuxClick: (event: React.MouseEvent) => {
+            if (event.button === 1) {
+              event.preventDefault()
+              redirectTask(record, true)
+            }
+          },
+        })}
       />
     </Stack>
   )

--- a/client/src/core/application/pages/ReviewApplicationPage/ReviewApplicationPage.tsx
+++ b/client/src/core/application/pages/ReviewApplicationPage/ReviewApplicationPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { useNavigate, useParams } from 'react-router'
+import { useLocation, useNavigate, useParams } from 'react-router'
 import type { IApplication } from '@/core/application/requests/responses/application'
 import { ApplicationState } from '@/core/application/requests/responses/application'
 import { doRequest } from '@/core/requests/request'
@@ -12,6 +12,7 @@ import ApplicationModal from '@/core/application/components/ApplicationModal/App
 
 const ReviewApplicationPage = () => {
   const navigate = useNavigate()
+  const location = useLocation()
   const { applicationId } = useParams<{ applicationId: string }>()
 
   usePageTitle('Review Applications')
@@ -49,7 +50,7 @@ const ReviewApplicationPage = () => {
         <ApplicationModal
           application={application}
           onClose={() => {
-            void navigate('/applications', { replace: true })
+            void navigate({ pathname: '/applications', search: location.search }, { replace: true })
 
             setApplication(undefined)
           }}
@@ -65,9 +66,13 @@ const ReviewApplicationPage = () => {
             selected={application}
             isSmallScreen={isSmallScreen}
             onSelect={(newApplication) => {
-              void navigate(`/applications/${newApplication.applicationId}`, {
-                replace: true,
-              })
+              void navigate(
+                {
+                  pathname: `/applications/${newApplication.applicationId}`,
+                  search: location.search,
+                },
+                { replace: true },
+              )
 
               setApplication(newApplication)
             }}
@@ -81,7 +86,10 @@ const ReviewApplicationPage = () => {
                 onChange={setApplication}
                 onDelete={() => {
                   setApplication(undefined)
-                  void navigate('/applications', { replace: true })
+                  void navigate(
+                    { pathname: '/applications', search: location.search },
+                    { replace: true },
+                  )
                 }}
               />
             ) : (

--- a/client/src/core/application/pages/ReviewApplicationPage/ReviewApplicationPage.tsx
+++ b/client/src/core/application/pages/ReviewApplicationPage/ReviewApplicationPage.tsx
@@ -43,6 +43,7 @@ const ReviewApplicationPage = () => {
       limit={10}
       defaultStates={[ApplicationState.NOT_ASSESSED]}
       showOnlyAssignedTopics={true}
+      persistState
     >
       {isSmallScreen && (
         <ApplicationModal

--- a/client/src/core/application/providers/ApplicationsProvider/ApplicationsProvider.tsx
+++ b/client/src/core/application/providers/ApplicationsProvider/ApplicationsProvider.tsx
@@ -124,6 +124,9 @@ const ApplicationsProvider = (props: PropsWithChildren<IApplicationsProviderProp
   const filterStatesKey = adjustedFilters.states?.join(',')
   const filterTopicsKey = adjustedFilters.topics?.join(',')
   const filterTypesKey = adjustedFilters.types?.join(',')
+  // URL sync uses the raw user-selected topics so the implicit
+  // `showOnlyAssignedTopics` expansion is not leaked into `?topics=` params.
+  const urlTopicsKey = filters.topics?.join(',')
   const topicsLoaded = !!topics
 
   const didMountRef = useRef(false)
@@ -219,14 +222,14 @@ const ApplicationsProvider = (props: PropsWithChildren<IApplicationsProviderProp
     setOrDelete('page', page > 0 ? String(page) : undefined)
     setOrDelete('search', filters.search)
     setOrDelete('states', filterStatesKey)
-    setOrDelete('topics', filterTopicsKey)
+    setOrDelete('topics', urlTopicsKey)
     setOrDelete('types', filterTypesKey)
     setOrDelete('sortBy', sort.column !== DEFAULT_SORT.column ? sort.column : undefined)
     setOrDelete('sortOrder', sort.direction !== DEFAULT_SORT.direction ? sort.direction : undefined)
 
     setSearchParams(params, { replace: true })
     // eslint-disable-next-line @eslint-react/exhaustive-deps -- searchParams/setSearchParams change on every navigation; only sync URL when actual state changes
-  }, [persistState, page, filters.search, filterStatesKey, filterTopicsKey, filterTypesKey, sort])
+  }, [persistState, page, filters.search, filterStatesKey, urlTopicsKey, filterTypesKey, sort])
 
   const fetchApplication = async (applicationId: string): Promise<IApplication | null> => {
     return new Promise((resolve) => {

--- a/client/src/core/application/providers/ApplicationsProvider/ApplicationsProvider.tsx
+++ b/client/src/core/application/providers/ApplicationsProvider/ApplicationsProvider.tsx
@@ -34,6 +34,8 @@ interface IApplicationsProviderProps {
 }
 
 const DEFAULT_SORT: IApplicationsSort = { column: 'createdAt', direction: 'desc' }
+const SORT_COLUMNS: IApplicationsSort['column'][] = ['createdAt', 'updatedAt']
+const SORT_DIRECTIONS: IApplicationsSort['direction'][] = ['asc', 'desc']
 
 const ApplicationsProvider = (props: PropsWithChildren<IApplicationsProviderProps>) => {
   const {
@@ -86,11 +88,15 @@ const ApplicationsProvider = (props: PropsWithChildren<IApplicationsProviderProp
   })
   const [sort, setSort] = useState<IApplicationsSort>(() => {
     if (!persistState) return DEFAULT_SORT
-    const column = searchParams.get('sortBy') as IApplicationsSort['column'] | null
-    const direction = searchParams.get('sortOrder') as IApplicationsSort['direction'] | null
+    const column = searchParams.get('sortBy')
+    const direction = searchParams.get('sortOrder')
     return {
-      column: column ?? DEFAULT_SORT.column,
-      direction: direction ?? DEFAULT_SORT.direction,
+      column: SORT_COLUMNS.includes(column as IApplicationsSort['column'])
+        ? (column as IApplicationsSort['column'])
+        : DEFAULT_SORT.column,
+      direction: SORT_DIRECTIONS.includes(direction as IApplicationsSort['direction'])
+        ? (direction as IApplicationsSort['direction'])
+        : DEFAULT_SORT.direction,
     }
   })
 
@@ -120,7 +126,12 @@ const ApplicationsProvider = (props: PropsWithChildren<IApplicationsProviderProp
   const filterTypesKey = adjustedFilters.types?.join(',')
   const topicsLoaded = !!topics
 
+  const didMountRef = useRef(false)
   useEffect(() => {
+    if (!didMountRef.current) {
+      didMountRef.current = true
+      return
+    }
     setPage(0)
   }, [sort, adjustedFilters])
 

--- a/client/src/core/application/providers/ApplicationsProvider/ApplicationsProvider.tsx
+++ b/client/src/core/application/providers/ApplicationsProvider/ApplicationsProvider.tsx
@@ -127,16 +127,9 @@ const ApplicationsProvider = (props: PropsWithChildren<IApplicationsProviderProp
   // URL sync uses the raw user-selected topics so the implicit
   // `showOnlyAssignedTopics` expansion is not leaked into `?topics=` params.
   const urlTopicsKey = filters.topics?.join(',')
+  const defaultStatesKey = defaultStates?.join(',')
+  const defaultTopicsKey = defaultTopics?.join(',')
   const topicsLoaded = !!topics
-
-  const didMountRef = useRef(false)
-  useEffect(() => {
-    if (!didMountRef.current) {
-      didMountRef.current = true
-      return
-    }
-    setPage(0)
-  }, [sort, adjustedFilters])
 
   useEffect(() => {
     setApplications(undefined)
@@ -219,17 +212,33 @@ const ApplicationsProvider = (props: PropsWithChildren<IApplicationsProviderProp
       }
     }
 
+    // Only write params that differ from the page-level defaults, so a freshly
+    // loaded `/applications` stays at a clean URL until the user actually
+    // changes filters/sort/page.
     setOrDelete('page', page > 0 ? String(page) : undefined)
     setOrDelete('search', filters.search)
-    setOrDelete('states', filterStatesKey)
-    setOrDelete('topics', urlTopicsKey)
+    setOrDelete(
+      'states',
+      filterStatesKey !== defaultStatesKey ? (filterStatesKey ?? '') : undefined,
+    )
+    setOrDelete('topics', urlTopicsKey !== defaultTopicsKey ? (urlTopicsKey ?? '') : undefined)
     setOrDelete('types', filterTypesKey)
     setOrDelete('sortBy', sort.column !== DEFAULT_SORT.column ? sort.column : undefined)
     setOrDelete('sortOrder', sort.direction !== DEFAULT_SORT.direction ? sort.direction : undefined)
 
     setSearchParams(params, { replace: true })
     // eslint-disable-next-line @eslint-react/exhaustive-deps -- searchParams/setSearchParams change on every navigation; only sync URL when actual state changes
-  }, [persistState, page, filters.search, filterStatesKey, urlTopicsKey, filterTypesKey, sort])
+  }, [
+    persistState,
+    page,
+    filters.search,
+    filterStatesKey,
+    urlTopicsKey,
+    filterTypesKey,
+    defaultStatesKey,
+    defaultTopicsKey,
+    sort,
+  ])
 
   const fetchApplication = async (applicationId: string): Promise<IApplication | null> => {
     return new Promise((resolve) => {

--- a/client/src/core/application/providers/ApplicationsProvider/ApplicationsProvider.tsx
+++ b/client/src/core/application/providers/ApplicationsProvider/ApplicationsProvider.tsx
@@ -1,5 +1,6 @@
 import type { PropsWithChildren, ReactNode } from 'react'
 import React, { useEffect, useMemo, useRef, useState } from 'react'
+import { useSearchParams } from 'react-router'
 import { doRequest } from '@/core/requests/request'
 import type { PaginationResponse } from '@/core/requests/responses/pagination'
 import type {
@@ -26,7 +27,13 @@ interface IApplicationsProviderProps {
   showOnlyAssignedTopics?: boolean
   hideIfEmpty?: boolean
   emptyComponent?: ReactNode
+  // When true, the provider reads its initial page/filters/sort from the URL
+  // search params and pushes subsequent changes back to the URL. Only enable on
+  // routes where this provider owns the URL state.
+  persistState?: boolean
 }
+
+const DEFAULT_SORT: IApplicationsSort = { column: 'createdAt', direction: 'desc' }
 
 const ApplicationsProvider = (props: PropsWithChildren<IApplicationsProviderProps>) => {
   const {
@@ -38,24 +45,53 @@ const ApplicationsProvider = (props: PropsWithChildren<IApplicationsProviderProp
     fetchAll = false,
     hideIfEmpty = false,
     emptyComponent,
+    persistState = false,
   } = props
 
   const user = useLoggedInUser()
   const topics = useAllTopics()
 
+  const [searchParams, setSearchParams] = useSearchParams()
+
   const [applications, setApplications] = useState<PaginationResponse<IApplication>>()
-  const [page, setPage] = useState(0)
+
+  const [page, setPage] = useState(() => {
+    if (!persistState) return 0
+    const raw = parseInt(searchParams.get('page') ?? '', 10)
+    return Number.isFinite(raw) && raw >= 0 ? raw : 0
+  })
 
   const previousContent = useRef<string[]>([])
 
-  const [filters, setFilters] = useState<IApplicationsFilters>({
-    states: defaultStates,
-    topics: defaultTopics,
-    includeSuggestedTopics: true,
+  const [filters, setFilters] = useState<IApplicationsFilters>(() => {
+    const base: IApplicationsFilters = {
+      states: defaultStates,
+      topics: defaultTopics,
+      includeSuggestedTopics: true,
+    }
+    if (!persistState) return base
+
+    const statesParam = searchParams.get('states')
+    const topicsParam = searchParams.get('topics')
+    const typesParam = searchParams.get('types')
+    return {
+      ...base,
+      search: searchParams.get('search') ?? base.search,
+      states: statesParam
+        ? (statesParam.split(',').filter(Boolean) as ApplicationState[])
+        : base.states,
+      topics: topicsParam ? topicsParam.split(',').filter(Boolean) : base.topics,
+      types: typesParam ? typesParam.split(',').filter(Boolean) : base.types,
+    }
   })
-  const [sort, setSort] = useState<IApplicationsSort>({
-    column: 'createdAt',
-    direction: 'desc',
+  const [sort, setSort] = useState<IApplicationsSort>(() => {
+    if (!persistState) return DEFAULT_SORT
+    const column = searchParams.get('sortBy') as IApplicationsSort['column'] | null
+    const direction = searchParams.get('sortOrder') as IApplicationsSort['direction'] | null
+    return {
+      column: column ?? DEFAULT_SORT.column,
+      direction: direction ?? DEFAULT_SORT.direction,
+    }
   })
 
   const adjustedFilters = useMemo(() => {
@@ -155,6 +191,31 @@ const ApplicationsProvider = (props: PropsWithChildren<IApplicationsProviderProp
     debouncedSearch,
     topicsLoaded,
   ])
+
+  useEffect(() => {
+    if (!persistState) return
+
+    const params = new URLSearchParams(searchParams)
+
+    const setOrDelete = (key: string, value: string | undefined) => {
+      if (value && value.length > 0) {
+        params.set(key, value)
+      } else {
+        params.delete(key)
+      }
+    }
+
+    setOrDelete('page', page > 0 ? String(page) : undefined)
+    setOrDelete('search', filters.search)
+    setOrDelete('states', filterStatesKey)
+    setOrDelete('topics', filterTopicsKey)
+    setOrDelete('types', filterTypesKey)
+    setOrDelete('sortBy', sort.column !== DEFAULT_SORT.column ? sort.column : undefined)
+    setOrDelete('sortOrder', sort.direction !== DEFAULT_SORT.direction ? sort.direction : undefined)
+
+    setSearchParams(params, { replace: true })
+    // eslint-disable-next-line @eslint-react/exhaustive-deps -- searchParams/setSearchParams change on every navigation; only sync URL when actual state changes
+  }, [persistState, page, filters.search, filterStatesKey, filterTopicsKey, filterTypesKey, sort])
 
   const fetchApplication = async (applicationId: string): Promise<IApplication | null> => {
     return new Promise((resolve) => {

--- a/client/src/core/topic/components/TopicsTable/TopicsTable.tsx
+++ b/client/src/core/topic/components/TopicsTable/TopicsTable.tsx
@@ -1,11 +1,12 @@
 import type { DataTableColumn } from 'mantine-datatable'
 import { DataTable } from 'mantine-datatable'
+import React from 'react'
 import { formatDate } from '@/core/utils/format'
 import { useTopicsContext } from '@/core/topic/providers/TopicsProvider/hooks'
 import type { ITopicOverview } from '@/core/topic/requests/responses/topic'
 import { TopicState } from '@/core/topic/requests/responses/topic'
-import { Link, useNavigate } from 'react-router'
-import { Badge, Box, Center, Stack, Text } from '@mantine/core'
+import { useNavigate } from 'react-router'
+import { Badge, Center, Stack, Text } from '@mantine/core'
 import AvatarUserList from '@/core/components/AvatarUserList/AvatarUserList'
 import ThesisTypeBadge from '@/app/pages/LandingPage/components/ThesisTypBadge/ThesisTypBadge'
 
@@ -35,6 +36,15 @@ const TopicsTable = (props: ITopicOverviewsTableProps) => {
   const navigate = useNavigate()
 
   const { topics, page, setPage, limit, isLoading } = useTopicsContext()
+
+  const openTopic = (topicId: string, openInNewTab: boolean) => {
+    const url = `/topics/${topicId}`
+    if (openInNewTab) {
+      window.open(url, '_blank', 'noopener,noreferrer')
+    } else {
+      void navigate(url)
+    }
+  }
 
   const getTopicColor = (state: TopicState) => {
     switch (state) {
@@ -69,15 +79,6 @@ const TopicsTable = (props: ITopicOverviewsTableProps) => {
       accessor: 'title',
       title: 'Title',
       cellsStyle: () => ({ minWidth: 200 }),
-      render: (record) => (
-        <Box
-          component={Link}
-          to={`/topics/${record.topicId}`}
-          style={{ textDecoration: 'none', color: 'inherit' }}
-        >
-          <Box w={'100%'}>{record.title}</Box>
-        </Box>
-      ),
     },
     types: {
       accessor: 'thesisTypes',
@@ -146,9 +147,17 @@ const TopicsTable = (props: ITopicOverviewsTableProps) => {
       records={topics?.content}
       idAccessor='topicId'
       columns={columns.map((column) => columnConfig[column])}
-      onRowClick={({ record }) => {
-        void navigate(`/topics/${record.topicId}`)
+      onRowClick={({ record, event }) => {
+        openTopic(record.topicId, event.metaKey || event.ctrlKey || event.shiftKey)
       }}
+      customRowAttributes={(record) => ({
+        onAuxClick: (event: React.MouseEvent) => {
+          if (event.button === 1) {
+            event.preventDefault()
+            openTopic(record.topicId, true)
+          }
+        },
+      })}
     />
   )
 }

--- a/client/src/core/topic/pages/ManageTopicsPage/ManageTopicsPage.tsx
+++ b/client/src/core/topic/pages/ManageTopicsPage/ManageTopicsPage.tsx
@@ -16,7 +16,7 @@ const ManageTopicsPage = () => {
   const [createTopicModal, setCreateTopicModal] = useState(false)
 
   return (
-    <TopicsProvider limit={20}>
+    <TopicsProvider limit={20} persistState>
       <Stack gap='md'>
         <Group>
           <Title>Manage Topics</Title>

--- a/client/src/core/topic/providers/TopicsProvider/TopicsProvider.tsx
+++ b/client/src/core/topic/providers/TopicsProvider/TopicsProvider.tsx
@@ -1,5 +1,6 @@
 import type { PropsWithChildren } from 'react'
 import React, { useEffect, useMemo, useRef, useState } from 'react'
+import { useSearchParams } from 'react-router'
 import { doRequest } from '@/core/requests/request'
 import { showSimpleError } from '@/core/utils/notification'
 import type { ITopicOverview } from '@/core/topic/requests/responses/topic'
@@ -14,6 +15,11 @@ interface ITopicsProviderProps {
   researchSpecific?: boolean
   initialFilters?: Partial<ITopicsFilters>
   states?: TopicState[]
+  // When true, the provider reads its initial page/search/state/type filters
+  // from the URL search params and pushes subsequent changes back to the URL.
+  // Only enable on pages where this provider owns the URL state (i.e. not on
+  // the LandingPage, which manages its own search params).
+  persistState?: boolean
 }
 
 const TopicsProvider = (props: PropsWithChildren<ITopicsProviderProps>) => {
@@ -24,14 +30,35 @@ const TopicsProvider = (props: PropsWithChildren<ITopicsProviderProps>) => {
     researchSpecific = true,
     initialFilters,
     states = [],
+    persistState = false,
   } = props
 
+  const [searchParams, setSearchParams] = useSearchParams()
+
   const [topics, setTopics] = useState<PaginationResponse<ITopicOverview>>()
-  const [page, setPage] = useState(0)
-  const [filters, setFilters] = useState<ITopicsFilters>({
-    states: states,
-    researchSpecific: researchSpecific,
-    ...initialFilters,
+
+  const [page, setPage] = useState(() => {
+    if (!persistState) return 0
+    const raw = parseInt(searchParams.get('page') ?? '', 10)
+    return Number.isFinite(raw) && raw >= 0 ? raw : 0
+  })
+
+  const [filters, setFilters] = useState<ITopicsFilters>(() => {
+    const base: ITopicsFilters = {
+      states: states,
+      researchSpecific: researchSpecific,
+      ...initialFilters,
+    }
+    if (!persistState) return base
+
+    const statesParam = searchParams.get('states')
+    const typesParam = searchParams.get('types')
+    return {
+      ...base,
+      search: searchParams.get('search') ?? base.search,
+      states: statesParam ? statesParam.split(',').filter(Boolean) : base.states,
+      types: typesParam ? typesParam.split(',').filter(Boolean) : base.types,
+    }
   })
 
   const [isLoading, setIsLoading] = useState(false)
@@ -79,6 +106,31 @@ const TopicsProvider = (props: PropsWithChildren<ITopicsProviderProps>) => {
     return fetchTopics()
     // eslint-disable-next-line @eslint-react/exhaustive-deps -- fetchTopics is recreated each render; only refetch when filters/pagination change
   }, [filters, page, limit])
+
+  const filterStatesKey = filters.states?.join(',')
+  const filterTypesKey = filters.types?.join(',')
+
+  useEffect(() => {
+    if (!persistState) return
+
+    const params = new URLSearchParams(searchParams)
+
+    const setOrDelete = (key: string, value: string | undefined) => {
+      if (value && value.length > 0) {
+        params.set(key, value)
+      } else {
+        params.delete(key)
+      }
+    }
+
+    setOrDelete('page', page > 0 ? String(page) : undefined)
+    setOrDelete('search', filters.search)
+    setOrDelete('states', filterStatesKey)
+    setOrDelete('types', filterTypesKey)
+
+    setSearchParams(params, { replace: true })
+    // eslint-disable-next-line @eslint-react/exhaustive-deps -- searchParams/setSearchParams change on every navigation; only sync URL when actual state changes
+  }, [persistState, page, filters.search, filterStatesKey, filterTypesKey])
 
   const initialFiltersKey = JSON.stringify(initialFilters)
   const prevInitialFiltersKeyRef = useRef(initialFiltersKey)

--- a/client/src/presentation/components/PresentationsTable/PresentationsTable.tsx
+++ b/client/src/presentation/components/PresentationsTable/PresentationsTable.tsx
@@ -35,7 +35,8 @@ type PresentationColumn =
 interface IPresentationsTableProps<T> {
   presentations: T[] | undefined
   theses: IPublishedThesis[]
-  onRowClick?: (presentation: T) => unknown
+  onRowClick?: (presentation: T, event: React.MouseEvent) => unknown
+  customRowAttributes?: (presentation: T, index: number) => Record<string, unknown>
   columns?: PresentationColumn[]
   extraColumns?: Record<PresentationColumn, DataTableColumn<T>>
   pagination?: {
@@ -54,6 +55,7 @@ const PresentationsTable = <T extends IThesisPresentation | IPublishedPresentati
     presentations,
     theses,
     onRowClick,
+    customRowAttributes,
     columns = ['type', 'location', 'streamUrl', 'language', 'scheduledAt'],
     extraColumns,
     pagination,
@@ -253,7 +255,8 @@ const PresentationsTable = <T extends IThesisPresentation | IPublishedPresentati
           onPageChange={pagination.onPageChange}
           idAccessor='presentationId'
           columns={columns.filter((column) => column).map((column) => columnConfig[column])}
-          onRowClick={onRowClick ? ({ record }) => onRowClick(record) : undefined}
+          onRowClick={onRowClick ? ({ record, event }) => onRowClick(record, event) : undefined}
+          customRowAttributes={customRowAttributes}
         />
       ) : (
         <DataTable

--- a/client/src/presentation/components/PublicPresentationsTable/PublicPresentationsTable.tsx
+++ b/client/src/presentation/components/PublicPresentationsTable/PublicPresentationsTable.tsx
@@ -19,6 +19,15 @@ const PublicPresentationsTable = (props: IPublicPresentationsTableProps) => {
 
   const navigate = useNavigate()
 
+  const openPresentation = (presentationId: string, openInNewTab: boolean) => {
+    const url = `/presentations/${presentationId}`
+    if (openInNewTab) {
+      window.open(url, '_blank', 'noopener,noreferrer')
+    } else {
+      void navigate(url)
+    }
+  }
+
   const [presentations, setPresentations] = useState<PaginationResponse<IPublishedPresentation>>()
   const [page, setPage] = useState(0)
   const [version, setVersion] = useState(0)
@@ -65,7 +74,20 @@ const PublicPresentationsTable = (props: IPublicPresentationsTableProps) => {
       }
       presentations={presentations?.content}
       theses={(presentations?.content ?? []).map((row) => row.thesis)}
-      onRowClick={(presentation) => navigate(`/presentations/${presentation.presentationId}`)}
+      onRowClick={(presentation, event) =>
+        openPresentation(
+          presentation.presentationId,
+          event.metaKey || event.ctrlKey || event.shiftKey,
+        )
+      }
+      customRowAttributes={(presentation) => ({
+        onAuxClick: (event: React.MouseEvent) => {
+          if (event.button === 1) {
+            event.preventDefault()
+            openPresentation(presentation.presentationId, true)
+          }
+        },
+      })}
       pagination={{
         totalRecords: presentations?.totalElements ?? 0,
         recordsPerPage: limit,

--- a/client/src/thesis/components/ThesesTable/ThesesTable.tsx
+++ b/client/src/thesis/components/ThesesTable/ThesesTable.tsx
@@ -46,8 +46,13 @@ const ThesesTable = (props: IThesesTableProps) => {
 
   const navigate = useNavigate()
 
-  const onThesisClick = (thesis: IThesisOverview) => {
-    void navigate(`/theses/${thesis.thesisId}`)
+  const openThesis = (thesisId: string, openInNewTab: boolean) => {
+    const url = `/theses/${thesisId}`
+    if (openInNewTab) {
+      window.open(url, '_blank', 'noopener,noreferrer')
+    } else {
+      void navigate(url)
+    }
   }
 
   const columnConfig: Record<ThesisColumn, DataTableColumn<IThesisOverview>> = {
@@ -155,7 +160,17 @@ const ThesesTable = (props: IThesesTableProps) => {
       records={theses?.content}
       idAccessor='thesisId'
       columns={columns.map((column) => columnConfig[column])}
-      onRowClick={({ record: thesis }) => onThesisClick(thesis)}
+      onRowClick={({ record: thesis, event }) => {
+        openThesis(thesis.thesisId, event.metaKey || event.ctrlKey || event.shiftKey)
+      }}
+      customRowAttributes={(record) => ({
+        onAuxClick: (event: React.MouseEvent) => {
+          if (event.button === 1) {
+            event.preventDefault()
+            openThesis(record.thesisId, true)
+          }
+        },
+      })}
     />
   )
 }

--- a/client/src/thesis/pages/BrowseThesesPage/BrowseThesesPage.tsx
+++ b/client/src/thesis/pages/BrowseThesesPage/BrowseThesesPage.tsx
@@ -16,7 +16,7 @@ const BrowseThesesPage = () => {
   const managementAccess = useManagementAccess()
 
   return (
-    <ThesesProvider fetchAll={true} limit={20}>
+    <ThesesProvider fetchAll={true} limit={20} persistState>
       <Stack>
         <Group>
           <Title>Browse Theses</Title>

--- a/client/src/thesis/providers/ThesesProvider/ThesesProvider.tsx
+++ b/client/src/thesis/providers/ThesesProvider/ThesesProvider.tsx
@@ -1,5 +1,6 @@
 import type { PropsWithChildren } from 'react'
 import React, { useEffect, useMemo, useState } from 'react'
+import { useSearchParams } from 'react-router'
 import type {
   IThesesContext,
   IThesesFilters,
@@ -18,20 +19,58 @@ interface IThesesProviderProps {
   limit: number
   defaultStates?: ThesisState[]
   hideIfEmpty?: boolean
+  // When true, the provider reads its initial page/filters/sort from the URL
+  // search params and pushes subsequent changes back to the URL so browser back
+  // restores the previous state. Only enable on pages where this provider owns
+  // the URL state (i.e. no other URL-synced provider on the same route).
+  persistState?: boolean
 }
 
+const DEFAULT_SORT: IThesesSort = { column: 'startDate', direction: 'asc' }
+
 const ThesesProvider = (props: PropsWithChildren<IThesesProviderProps>) => {
-  const { children, fetchAll = false, limit, hideIfEmpty = false, defaultStates } = props
+  const {
+    children,
+    fetchAll = false,
+    limit,
+    hideIfEmpty = false,
+    defaultStates,
+    persistState = false,
+  } = props
+
+  const [searchParams, setSearchParams] = useSearchParams()
 
   const [theses, setTheses] = useState<PaginationResponse<IThesisOverview>>()
-  const [page, setPage] = useState(0)
 
-  const [filters, setFilters] = useState<IThesesFilters>({
-    states: defaultStates,
+  const [page, setPage] = useState(() => {
+    if (!persistState) return 0
+    const raw = parseInt(searchParams.get('page') ?? '', 10)
+    return Number.isFinite(raw) && raw >= 0 ? raw : 0
   })
-  const [sort, setSort] = useState<IThesesSort>({
-    column: 'startDate',
-    direction: 'asc',
+
+  const [filters, setFilters] = useState<IThesesFilters>(() => {
+    if (!persistState) {
+      return { states: defaultStates }
+    }
+    const statesParam = searchParams.get('states')
+    const typesParam = searchParams.get('types')
+    return {
+      search: searchParams.get('search') ?? undefined,
+      states: statesParam
+        ? (statesParam.split(',').filter(Boolean) as ThesisState[])
+        : defaultStates,
+      types: typesParam ? typesParam.split(',').filter(Boolean) : undefined,
+    }
+  })
+
+  const [sort, setSort] = useState<IThesesSort>(() => {
+    if (!persistState) return DEFAULT_SORT
+    const column = searchParams.get('sortBy') as IThesesSort['column'] | null
+    const direction = searchParams.get('sortOrder') as IThesesSort['direction'] | null
+    return {
+      column: column ?? DEFAULT_SORT.column,
+      direction: direction ?? DEFAULT_SORT.direction,
+    }
   })
 
   const [debouncedSearch] = useDebouncedValue(filters.search ?? '', 500)
@@ -77,6 +116,30 @@ const ThesesProvider = (props: PropsWithChildren<IThesesProviderProps>) => {
     )
     // eslint-disable-next-line @eslint-react/exhaustive-deps -- filters.states/types are tracked via joined keys below to avoid identity-based reruns
   }, [fetchAll, page, limit, sort, filterStatesKey, filterTypesKey, debouncedSearch])
+
+  useEffect(() => {
+    if (!persistState) return
+
+    const params = new URLSearchParams(searchParams)
+
+    const setOrDelete = (key: string, value: string | undefined) => {
+      if (value && value.length > 0) {
+        params.set(key, value)
+      } else {
+        params.delete(key)
+      }
+    }
+
+    setOrDelete('page', page > 0 ? String(page) : undefined)
+    setOrDelete('search', filters.search)
+    setOrDelete('states', filterStatesKey)
+    setOrDelete('types', filterTypesKey)
+    setOrDelete('sortBy', sort.column !== DEFAULT_SORT.column ? sort.column : undefined)
+    setOrDelete('sortOrder', sort.direction !== DEFAULT_SORT.direction ? sort.direction : undefined)
+
+    setSearchParams(params, { replace: true })
+    // eslint-disable-next-line @eslint-react/exhaustive-deps -- searchParams/setSearchParams change on every navigation; only sync URL when actual state changes
+  }, [persistState, page, filters.search, filterStatesKey, filterTypesKey, sort])
 
   const contextState = useMemo<IThesesContext>(() => {
     return {

--- a/client/src/thesis/providers/ThesesProvider/ThesesProvider.tsx
+++ b/client/src/thesis/providers/ThesesProvider/ThesesProvider.tsx
@@ -27,6 +27,8 @@ interface IThesesProviderProps {
 }
 
 const DEFAULT_SORT: IThesesSort = { column: 'startDate', direction: 'asc' }
+const SORT_COLUMNS: IThesesSort['column'][] = ['startDate', 'endDate', 'createdAt']
+const SORT_DIRECTIONS: IThesesSort['direction'][] = ['asc', 'desc']
 
 const ThesesProvider = (props: PropsWithChildren<IThesesProviderProps>) => {
   const {
@@ -65,11 +67,15 @@ const ThesesProvider = (props: PropsWithChildren<IThesesProviderProps>) => {
 
   const [sort, setSort] = useState<IThesesSort>(() => {
     if (!persistState) return DEFAULT_SORT
-    const column = searchParams.get('sortBy') as IThesesSort['column'] | null
-    const direction = searchParams.get('sortOrder') as IThesesSort['direction'] | null
+    const column = searchParams.get('sortBy')
+    const direction = searchParams.get('sortOrder')
     return {
-      column: column ?? DEFAULT_SORT.column,
-      direction: direction ?? DEFAULT_SORT.direction,
+      column: SORT_COLUMNS.includes(column as IThesesSort['column'])
+        ? (column as IThesesSort['column'])
+        : DEFAULT_SORT.column,
+      direction: SORT_DIRECTIONS.includes(direction as IThesesSort['direction'])
+        ? (direction as IThesesSort['direction'])
+        : DEFAULT_SORT.direction,
     }
   })
 


### PR DESCRIPTION
## Summary
- **New-tab row clicks**: Cmd/Ctrl/Shift+click and middle-click on rows in the theses, topics, public presentations, and dashboard task tables now open the target in a new tab. Plain click still navigates in the current tab. Removes the partial `<Link>` on the `TopicsTable` title cell that previously caused double-fire on Cmd+click.
- **Pagination/filters/sort persistence**: `ThesesProvider`, `TopicsProvider`, and `ApplicationsProvider` gain an opt-in `persistState` prop that mirrors page/search/filters/sort to URL search params (using `replace: true` so the URL doesn't pollute history). Enabled on `/theses`, `/topics`, and `/applications`. Browser back from a detail page now restores the previous list view.
- **Scoping**: `persistState` defaults to `false`, so call sites that share a route with other URL-owning state are unaffected (Dashboard, LandingPage, TopicPage, IntervieweesList, NotificationSettings, ThesisOverviewPage).

## Test plan
- [x] On `/theses`, page to page 2, open a thesis (plain click) → browser back → still on page 2.
- [x] On `/theses`, Cmd/Ctrl/Shift+click a row → opens detail in a new tab; current tab unchanged.
- [x] On `/theses`, middle-click a row → opens detail in a new tab.
- [x] Apply a state/type filter or change sort → URL reflects it (`?states=...&sortBy=...`); reload preserves filters; navigating away via the "Browse Theses" nav link resets to defaults.
- [x] Repeat the above on `/topics`.
- [x] On `/applications`, paginate the sidebar, select an application, then browser-back → previous page restored.
- [x] On the dashboard My Tasks section and the public presentations table, Cmd+click / middle-click → opens in new tab.
- [x] Regression: dashboard, landing page, and topic-page tables behave as before (no URL params change, no double navigation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added URL persistence for list state (filters, sort, and page) for applications, topics, and theses.
  * Updated table row navigation to support opening details in a new tab via modifier keys and middle-click.
  * Enhanced table components to provide richer row-click handling (including access to the click event and customizable row attributes).
* **Bug Fixes**
  * Improved consistency of multi-tab navigation behavior across list pages and tables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->