### PR TITLE
Revert "Preserve table pagination on back-nav and enable new-tab row clicks"

### DIFF
--- a/client/src/core/admin/pages/DashboardPage/components/MyTasksSection/MyTasksSection.tsx
+++ b/client/src/core/admin/pages/DashboardPage/components/MyTasksSection/MyTasksSection.tsx
@@ -40,10 +40,8 @@ const MyTasksSection = () => {
     return null
   }
 
-  const redirectTask = (task: ITask, openInNewTab = false) => {
-    if (openInNewTab) {
-      window.open(task.link, '_blank', 'noopener,noreferrer')
-    } else if (task.link.startsWith('http')) {
+  const redirectTask = (task: ITask) => {
+    if (task.link.startsWith('http')) {
       window.location.replace(task.link)
     } else {
       void navigate(task.link)
@@ -81,17 +79,7 @@ const MyTasksSection = () => {
             ),
           },
         ]}
-        onRowClick={({ record, event }) =>
-          redirectTask(record, event.metaKey || event.ctrlKey || event.shiftKey)
-        }
-        customRowAttributes={(record) => ({
-          onAuxClick: (event: React.MouseEvent) => {
-            if (event.button === 1) {
-              event.preventDefault()
-              redirectTask(record, true)
-            }
-          },
-        })}
+        onRowClick={({ record }) => redirectTask(record)}
       />
     </Stack>
   )

--- a/client/src/core/application/pages/ReviewApplicationPage/ReviewApplicationPage.tsx
+++ b/client/src/core/application/pages/ReviewApplicationPage/ReviewApplicationPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { useLocation, useNavigate, useParams } from 'react-router'
+import { useNavigate, useParams } from 'react-router'
 import type { IApplication } from '@/core/application/requests/responses/application'
 import { ApplicationState } from '@/core/application/requests/responses/application'
 import { doRequest } from '@/core/requests/request'
@@ -12,7 +12,6 @@ import ApplicationModal from '@/core/application/components/ApplicationModal/App
 
 const ReviewApplicationPage = () => {
   const navigate = useNavigate()
-  const location = useLocation()
   const { applicationId } = useParams<{ applicationId: string }>()
 
   usePageTitle('Review Applications')
@@ -44,13 +43,12 @@ const ReviewApplicationPage = () => {
       limit={10}
       defaultStates={[ApplicationState.NOT_ASSESSED]}
       showOnlyAssignedTopics={true}
-      persistState
     >
       {isSmallScreen && (
         <ApplicationModal
           application={application}
           onClose={() => {
-            void navigate({ pathname: '/applications', search: location.search }, { replace: true })
+            void navigate('/applications', { replace: true })
 
             setApplication(undefined)
           }}
@@ -66,13 +64,9 @@ const ReviewApplicationPage = () => {
             selected={application}
             isSmallScreen={isSmallScreen}
             onSelect={(newApplication) => {
-              void navigate(
-                {
-                  pathname: `/applications/${newApplication.applicationId}`,
-                  search: location.search,
-                },
-                { replace: true },
-              )
+              void navigate(`/applications/${newApplication.applicationId}`, {
+                replace: true,
+              })
 
               setApplication(newApplication)
             }}
@@ -86,10 +80,7 @@ const ReviewApplicationPage = () => {
                 onChange={setApplication}
                 onDelete={() => {
                   setApplication(undefined)
-                  void navigate(
-                    { pathname: '/applications', search: location.search },
-                    { replace: true },
-                  )
+                  void navigate('/applications', { replace: true })
                 }}
               />
             ) : (

--- a/client/src/core/application/providers/ApplicationsProvider/ApplicationsProvider.tsx
+++ b/client/src/core/application/providers/ApplicationsProvider/ApplicationsProvider.tsx
@@ -1,6 +1,5 @@
 import type { PropsWithChildren, ReactNode } from 'react'
 import React, { useEffect, useMemo, useRef, useState } from 'react'
-import { useSearchParams } from 'react-router'
 import { doRequest } from '@/core/requests/request'
 import type { PaginationResponse } from '@/core/requests/responses/pagination'
 import type {
@@ -27,15 +26,7 @@ interface IApplicationsProviderProps {
   showOnlyAssignedTopics?: boolean
   hideIfEmpty?: boolean
   emptyComponent?: ReactNode
-  // When true, the provider reads its initial page/filters/sort from the URL
-  // search params and pushes subsequent changes back to the URL. Only enable on
-  // routes where this provider owns the URL state.
-  persistState?: boolean
 }
-
-const DEFAULT_SORT: IApplicationsSort = { column: 'createdAt', direction: 'desc' }
-const SORT_COLUMNS: IApplicationsSort['column'][] = ['createdAt', 'updatedAt']
-const SORT_DIRECTIONS: IApplicationsSort['direction'][] = ['asc', 'desc']
 
 const ApplicationsProvider = (props: PropsWithChildren<IApplicationsProviderProps>) => {
   const {
@@ -47,57 +38,24 @@ const ApplicationsProvider = (props: PropsWithChildren<IApplicationsProviderProp
     fetchAll = false,
     hideIfEmpty = false,
     emptyComponent,
-    persistState = false,
   } = props
 
   const user = useLoggedInUser()
   const topics = useAllTopics()
 
-  const [searchParams, setSearchParams] = useSearchParams()
-
   const [applications, setApplications] = useState<PaginationResponse<IApplication>>()
-
-  const [page, setPage] = useState(() => {
-    if (!persistState) return 0
-    const raw = parseInt(searchParams.get('page') ?? '', 10)
-    return Number.isFinite(raw) && raw >= 0 ? raw : 0
-  })
+  const [page, setPage] = useState(0)
 
   const previousContent = useRef<string[]>([])
 
-  const [filters, setFilters] = useState<IApplicationsFilters>(() => {
-    const base: IApplicationsFilters = {
-      states: defaultStates,
-      topics: defaultTopics,
-      includeSuggestedTopics: true,
-    }
-    if (!persistState) return base
-
-    const statesParam = searchParams.get('states')
-    const topicsParam = searchParams.get('topics')
-    const typesParam = searchParams.get('types')
-    return {
-      ...base,
-      search: searchParams.get('search') ?? base.search,
-      states: statesParam
-        ? (statesParam.split(',').filter(Boolean) as ApplicationState[])
-        : base.states,
-      topics: topicsParam ? topicsParam.split(',').filter(Boolean) : base.topics,
-      types: typesParam ? typesParam.split(',').filter(Boolean) : base.types,
-    }
+  const [filters, setFilters] = useState<IApplicationsFilters>({
+    states: defaultStates,
+    topics: defaultTopics,
+    includeSuggestedTopics: true,
   })
-  const [sort, setSort] = useState<IApplicationsSort>(() => {
-    if (!persistState) return DEFAULT_SORT
-    const column = searchParams.get('sortBy')
-    const direction = searchParams.get('sortOrder')
-    return {
-      column: SORT_COLUMNS.includes(column as IApplicationsSort['column'])
-        ? (column as IApplicationsSort['column'])
-        : DEFAULT_SORT.column,
-      direction: SORT_DIRECTIONS.includes(direction as IApplicationsSort['direction'])
-        ? (direction as IApplicationsSort['direction'])
-        : DEFAULT_SORT.direction,
-    }
+  const [sort, setSort] = useState<IApplicationsSort>({
+    column: 'createdAt',
+    direction: 'desc',
   })
 
   const adjustedFilters = useMemo(() => {
@@ -124,12 +82,11 @@ const ApplicationsProvider = (props: PropsWithChildren<IApplicationsProviderProp
   const filterStatesKey = adjustedFilters.states?.join(',')
   const filterTopicsKey = adjustedFilters.topics?.join(',')
   const filterTypesKey = adjustedFilters.types?.join(',')
-  // URL sync uses the raw user-selected topics so the implicit
-  // `showOnlyAssignedTopics` expansion is not leaked into `?topics=` params.
-  const urlTopicsKey = filters.topics?.join(',')
-  const defaultStatesKey = defaultStates?.join(',')
-  const defaultTopicsKey = defaultTopics?.join(',')
   const topicsLoaded = !!topics
+
+  useEffect(() => {
+    setPage(0)
+  }, [sort, adjustedFilters])
 
   useEffect(() => {
     setApplications(undefined)
@@ -197,47 +154,6 @@ const ApplicationsProvider = (props: PropsWithChildren<IApplicationsProviderProp
     adjustedFilters.includeSuggestedTopics,
     debouncedSearch,
     topicsLoaded,
-  ])
-
-  useEffect(() => {
-    if (!persistState) return
-
-    const params = new URLSearchParams(searchParams)
-
-    const setOrDelete = (key: string, value: string | undefined) => {
-      if (value && value.length > 0) {
-        params.set(key, value)
-      } else {
-        params.delete(key)
-      }
-    }
-
-    // Only write params that differ from the page-level defaults, so a freshly
-    // loaded `/applications` stays at a clean URL until the user actually
-    // changes filters/sort/page.
-    setOrDelete('page', page > 0 ? String(page) : undefined)
-    setOrDelete('search', filters.search)
-    setOrDelete(
-      'states',
-      filterStatesKey !== defaultStatesKey ? (filterStatesKey ?? '') : undefined,
-    )
-    setOrDelete('topics', urlTopicsKey !== defaultTopicsKey ? (urlTopicsKey ?? '') : undefined)
-    setOrDelete('types', filterTypesKey)
-    setOrDelete('sortBy', sort.column !== DEFAULT_SORT.column ? sort.column : undefined)
-    setOrDelete('sortOrder', sort.direction !== DEFAULT_SORT.direction ? sort.direction : undefined)
-
-    setSearchParams(params, { replace: true })
-    // eslint-disable-next-line @eslint-react/exhaustive-deps -- searchParams/setSearchParams change on every navigation; only sync URL when actual state changes
-  }, [
-    persistState,
-    page,
-    filters.search,
-    filterStatesKey,
-    urlTopicsKey,
-    filterTypesKey,
-    defaultStatesKey,
-    defaultTopicsKey,
-    sort,
   ])
 
   const fetchApplication = async (applicationId: string): Promise<IApplication | null> => {

--- a/client/src/core/topic/components/TopicsTable/TopicsTable.tsx
+++ b/client/src/core/topic/components/TopicsTable/TopicsTable.tsx
@@ -1,12 +1,11 @@
 import type { DataTableColumn } from 'mantine-datatable'
 import { DataTable } from 'mantine-datatable'
-import React from 'react'
 import { formatDate } from '@/core/utils/format'
 import { useTopicsContext } from '@/core/topic/providers/TopicsProvider/hooks'
 import type { ITopicOverview } from '@/core/topic/requests/responses/topic'
 import { TopicState } from '@/core/topic/requests/responses/topic'
-import { useNavigate } from 'react-router'
-import { Badge, Center, Stack, Text } from '@mantine/core'
+import { Link, useNavigate } from 'react-router'
+import { Badge, Box, Center, Stack, Text } from '@mantine/core'
 import AvatarUserList from '@/core/components/AvatarUserList/AvatarUserList'
 import ThesisTypeBadge from '@/app/pages/LandingPage/components/ThesisTypBadge/ThesisTypBadge'
 
@@ -36,15 +35,6 @@ const TopicsTable = (props: ITopicOverviewsTableProps) => {
   const navigate = useNavigate()
 
   const { topics, page, setPage, limit, isLoading } = useTopicsContext()
-
-  const openTopic = (topicId: string, openInNewTab: boolean) => {
-    const url = `/topics/${topicId}`
-    if (openInNewTab) {
-      window.open(url, '_blank', 'noopener,noreferrer')
-    } else {
-      void navigate(url)
-    }
-  }
 
   const getTopicColor = (state: TopicState) => {
     switch (state) {
@@ -79,6 +69,15 @@ const TopicsTable = (props: ITopicOverviewsTableProps) => {
       accessor: 'title',
       title: 'Title',
       cellsStyle: () => ({ minWidth: 200 }),
+      render: (record) => (
+        <Box
+          component={Link}
+          to={`/topics/${record.topicId}`}
+          style={{ textDecoration: 'none', color: 'inherit' }}
+        >
+          <Box w={'100%'}>{record.title}</Box>
+        </Box>
+      ),
     },
     types: {
       accessor: 'thesisTypes',
@@ -147,17 +146,9 @@ const TopicsTable = (props: ITopicOverviewsTableProps) => {
       records={topics?.content}
       idAccessor='topicId'
       columns={columns.map((column) => columnConfig[column])}
-      onRowClick={({ record, event }) => {
-        openTopic(record.topicId, event.metaKey || event.ctrlKey || event.shiftKey)
+      onRowClick={({ record }) => {
+        void navigate(`/topics/${record.topicId}`)
       }}
-      customRowAttributes={(record) => ({
-        onAuxClick: (event: React.MouseEvent) => {
-          if (event.button === 1) {
-            event.preventDefault()
-            openTopic(record.topicId, true)
-          }
-        },
-      })}
     />
   )
 }

--- a/client/src/core/topic/pages/ManageTopicsPage/ManageTopicsPage.tsx
+++ b/client/src/core/topic/pages/ManageTopicsPage/ManageTopicsPage.tsx
@@ -16,7 +16,7 @@ const ManageTopicsPage = () => {
   const [createTopicModal, setCreateTopicModal] = useState(false)
 
   return (
-    <TopicsProvider limit={20} persistState>
+    <TopicsProvider limit={20}>
       <Stack gap='md'>
         <Group>
           <Title>Manage Topics</Title>

--- a/client/src/core/topic/providers/TopicsProvider/TopicsProvider.tsx
+++ b/client/src/core/topic/providers/TopicsProvider/TopicsProvider.tsx
@@ -1,6 +1,5 @@
 import type { PropsWithChildren } from 'react'
 import React, { useEffect, useMemo, useRef, useState } from 'react'
-import { useSearchParams } from 'react-router'
 import { doRequest } from '@/core/requests/request'
 import { showSimpleError } from '@/core/utils/notification'
 import type { ITopicOverview } from '@/core/topic/requests/responses/topic'
@@ -15,11 +14,6 @@ interface ITopicsProviderProps {
   researchSpecific?: boolean
   initialFilters?: Partial<ITopicsFilters>
   states?: TopicState[]
-  // When true, the provider reads its initial page/search/state/type filters
-  // from the URL search params and pushes subsequent changes back to the URL.
-  // Only enable on pages where this provider owns the URL state (i.e. not on
-  // the LandingPage, which manages its own search params).
-  persistState?: boolean
 }
 
 const TopicsProvider = (props: PropsWithChildren<ITopicsProviderProps>) => {
@@ -30,35 +24,14 @@ const TopicsProvider = (props: PropsWithChildren<ITopicsProviderProps>) => {
     researchSpecific = true,
     initialFilters,
     states = [],
-    persistState = false,
   } = props
 
-  const [searchParams, setSearchParams] = useSearchParams()
-
   const [topics, setTopics] = useState<PaginationResponse<ITopicOverview>>()
-
-  const [page, setPage] = useState(() => {
-    if (!persistState) return 0
-    const raw = parseInt(searchParams.get('page') ?? '', 10)
-    return Number.isFinite(raw) && raw >= 0 ? raw : 0
-  })
-
-  const [filters, setFilters] = useState<ITopicsFilters>(() => {
-    const base: ITopicsFilters = {
-      states: states,
-      researchSpecific: researchSpecific,
-      ...initialFilters,
-    }
-    if (!persistState) return base
-
-    const statesParam = searchParams.get('states')
-    const typesParam = searchParams.get('types')
-    return {
-      ...base,
-      search: searchParams.get('search') ?? base.search,
-      states: statesParam ? statesParam.split(',').filter(Boolean) : base.states,
-      types: typesParam ? typesParam.split(',').filter(Boolean) : base.types,
-    }
+  const [page, setPage] = useState(0)
+  const [filters, setFilters] = useState<ITopicsFilters>({
+    states: states,
+    researchSpecific: researchSpecific,
+    ...initialFilters,
   })
 
   const [isLoading, setIsLoading] = useState(false)
@@ -106,31 +79,6 @@ const TopicsProvider = (props: PropsWithChildren<ITopicsProviderProps>) => {
     return fetchTopics()
     // eslint-disable-next-line @eslint-react/exhaustive-deps -- fetchTopics is recreated each render; only refetch when filters/pagination change
   }, [filters, page, limit])
-
-  const filterStatesKey = filters.states?.join(',')
-  const filterTypesKey = filters.types?.join(',')
-
-  useEffect(() => {
-    if (!persistState) return
-
-    const params = new URLSearchParams(searchParams)
-
-    const setOrDelete = (key: string, value: string | undefined) => {
-      if (value && value.length > 0) {
-        params.set(key, value)
-      } else {
-        params.delete(key)
-      }
-    }
-
-    setOrDelete('page', page > 0 ? String(page) : undefined)
-    setOrDelete('search', filters.search)
-    setOrDelete('states', filterStatesKey)
-    setOrDelete('types', filterTypesKey)
-
-    setSearchParams(params, { replace: true })
-    // eslint-disable-next-line @eslint-react/exhaustive-deps -- searchParams/setSearchParams change on every navigation; only sync URL when actual state changes
-  }, [persistState, page, filters.search, filterStatesKey, filterTypesKey])
 
   const initialFiltersKey = JSON.stringify(initialFilters)
   const prevInitialFiltersKeyRef = useRef(initialFiltersKey)

--- a/client/src/presentation/components/PresentationsTable/PresentationsTable.tsx
+++ b/client/src/presentation/components/PresentationsTable/PresentationsTable.tsx
@@ -35,8 +35,7 @@ type PresentationColumn =
 interface IPresentationsTableProps<T> {
   presentations: T[] | undefined
   theses: IPublishedThesis[]
-  onRowClick?: (presentation: T, event: React.MouseEvent) => unknown
-  customRowAttributes?: (presentation: T, index: number) => Record<string, unknown>
+  onRowClick?: (presentation: T) => unknown
   columns?: PresentationColumn[]
   extraColumns?: Record<PresentationColumn, DataTableColumn<T>>
   pagination?: {
@@ -55,7 +54,6 @@ const PresentationsTable = <T extends IThesisPresentation | IPublishedPresentati
     presentations,
     theses,
     onRowClick,
-    customRowAttributes,
     columns = ['type', 'location', 'streamUrl', 'language', 'scheduledAt'],
     extraColumns,
     pagination,
@@ -255,8 +253,7 @@ const PresentationsTable = <T extends IThesisPresentation | IPublishedPresentati
           onPageChange={pagination.onPageChange}
           idAccessor='presentationId'
           columns={columns.filter((column) => column).map((column) => columnConfig[column])}
-          onRowClick={onRowClick ? ({ record, event }) => onRowClick(record, event) : undefined}
-          customRowAttributes={customRowAttributes}
+          onRowClick={onRowClick ? ({ record }) => onRowClick(record) : undefined}
         />
       ) : (
         <DataTable

--- a/client/src/presentation/components/PublicPresentationsTable/PublicPresentationsTable.tsx
+++ b/client/src/presentation/components/PublicPresentationsTable/PublicPresentationsTable.tsx
@@ -19,15 +19,6 @@ const PublicPresentationsTable = (props: IPublicPresentationsTableProps) => {
 
   const navigate = useNavigate()
 
-  const openPresentation = (presentationId: string, openInNewTab: boolean) => {
-    const url = `/presentations/${presentationId}`
-    if (openInNewTab) {
-      window.open(url, '_blank', 'noopener,noreferrer')
-    } else {
-      void navigate(url)
-    }
-  }
-
   const [presentations, setPresentations] = useState<PaginationResponse<IPublishedPresentation>>()
   const [page, setPage] = useState(0)
   const [version, setVersion] = useState(0)
@@ -74,20 +65,7 @@ const PublicPresentationsTable = (props: IPublicPresentationsTableProps) => {
       }
       presentations={presentations?.content}
       theses={(presentations?.content ?? []).map((row) => row.thesis)}
-      onRowClick={(presentation, event) =>
-        openPresentation(
-          presentation.presentationId,
-          event.metaKey || event.ctrlKey || event.shiftKey,
-        )
-      }
-      customRowAttributes={(presentation) => ({
-        onAuxClick: (event: React.MouseEvent) => {
-          if (event.button === 1) {
-            event.preventDefault()
-            openPresentation(presentation.presentationId, true)
-          }
-        },
-      })}
+      onRowClick={(presentation) => navigate(`/presentations/${presentation.presentationId}`)}
       pagination={{
         totalRecords: presentations?.totalElements ?? 0,
         recordsPerPage: limit,

--- a/client/src/thesis/components/ThesesTable/ThesesTable.tsx
+++ b/client/src/thesis/components/ThesesTable/ThesesTable.tsx
@@ -46,13 +46,8 @@ const ThesesTable = (props: IThesesTableProps) => {
 
   const navigate = useNavigate()
 
-  const openThesis = (thesisId: string, openInNewTab: boolean) => {
-    const url = `/theses/${thesisId}`
-    if (openInNewTab) {
-      window.open(url, '_blank', 'noopener,noreferrer')
-    } else {
-      void navigate(url)
-    }
+  const onThesisClick = (thesis: IThesisOverview) => {
+    void navigate(`/theses/${thesis.thesisId}`)
   }
 
   const columnConfig: Record<ThesisColumn, DataTableColumn<IThesisOverview>> = {
@@ -160,17 +155,7 @@ const ThesesTable = (props: IThesesTableProps) => {
       records={theses?.content}
       idAccessor='thesisId'
       columns={columns.map((column) => columnConfig[column])}
-      onRowClick={({ record: thesis, event }) => {
-        openThesis(thesis.thesisId, event.metaKey || event.ctrlKey || event.shiftKey)
-      }}
-      customRowAttributes={(record) => ({
-        onAuxClick: (event: React.MouseEvent) => {
-          if (event.button === 1) {
-            event.preventDefault()
-            openThesis(record.thesisId, true)
-          }
-        },
-      })}
+      onRowClick={({ record: thesis }) => onThesisClick(thesis)}
     />
   )
 }

--- a/client/src/thesis/pages/BrowseThesesPage/BrowseThesesPage.tsx
+++ b/client/src/thesis/pages/BrowseThesesPage/BrowseThesesPage.tsx
@@ -16,7 +16,7 @@ const BrowseThesesPage = () => {
   const managementAccess = useManagementAccess()
 
   return (
-    <ThesesProvider fetchAll={true} limit={20} persistState>
+    <ThesesProvider fetchAll={true} limit={20}>
       <Stack>
         <Group>
           <Title>Browse Theses</Title>

--- a/client/src/thesis/providers/ThesesProvider/ThesesProvider.tsx
+++ b/client/src/thesis/providers/ThesesProvider/ThesesProvider.tsx
@@ -1,6 +1,5 @@
 import type { PropsWithChildren } from 'react'
 import React, { useEffect, useMemo, useState } from 'react'
-import { useSearchParams } from 'react-router'
 import type {
   IThesesContext,
   IThesesFilters,
@@ -19,64 +18,20 @@ interface IThesesProviderProps {
   limit: number
   defaultStates?: ThesisState[]
   hideIfEmpty?: boolean
-  // When true, the provider reads its initial page/filters/sort from the URL
-  // search params and pushes subsequent changes back to the URL so browser back
-  // restores the previous state. Only enable on pages where this provider owns
-  // the URL state (i.e. no other URL-synced provider on the same route).
-  persistState?: boolean
 }
 
-const DEFAULT_SORT: IThesesSort = { column: 'startDate', direction: 'asc' }
-const SORT_COLUMNS: IThesesSort['column'][] = ['startDate', 'endDate', 'createdAt']
-const SORT_DIRECTIONS: IThesesSort['direction'][] = ['asc', 'desc']
-
 const ThesesProvider = (props: PropsWithChildren<IThesesProviderProps>) => {
-  const {
-    children,
-    fetchAll = false,
-    limit,
-    hideIfEmpty = false,
-    defaultStates,
-    persistState = false,
-  } = props
-
-  const [searchParams, setSearchParams] = useSearchParams()
+  const { children, fetchAll = false, limit, hideIfEmpty = false, defaultStates } = props
 
   const [theses, setTheses] = useState<PaginationResponse<IThesisOverview>>()
+  const [page, setPage] = useState(0)
 
-  const [page, setPage] = useState(() => {
-    if (!persistState) return 0
-    const raw = parseInt(searchParams.get('page') ?? '', 10)
-    return Number.isFinite(raw) && raw >= 0 ? raw : 0
+  const [filters, setFilters] = useState<IThesesFilters>({
+    states: defaultStates,
   })
-
-  const [filters, setFilters] = useState<IThesesFilters>(() => {
-    if (!persistState) {
-      return { states: defaultStates }
-    }
-    const statesParam = searchParams.get('states')
-    const typesParam = searchParams.get('types')
-    return {
-      search: searchParams.get('search') ?? undefined,
-      states: statesParam
-        ? (statesParam.split(',').filter(Boolean) as ThesisState[])
-        : defaultStates,
-      types: typesParam ? typesParam.split(',').filter(Boolean) : undefined,
-    }
-  })
-
-  const [sort, setSort] = useState<IThesesSort>(() => {
-    if (!persistState) return DEFAULT_SORT
-    const column = searchParams.get('sortBy')
-    const direction = searchParams.get('sortOrder')
-    return {
-      column: SORT_COLUMNS.includes(column as IThesesSort['column'])
-        ? (column as IThesesSort['column'])
-        : DEFAULT_SORT.column,
-      direction: SORT_DIRECTIONS.includes(direction as IThesesSort['direction'])
-        ? (direction as IThesesSort['direction'])
-        : DEFAULT_SORT.direction,
-    }
+  const [sort, setSort] = useState<IThesesSort>({
+    column: 'startDate',
+    direction: 'asc',
   })
 
   const [debouncedSearch] = useDebouncedValue(filters.search ?? '', 500)
@@ -122,30 +77,6 @@ const ThesesProvider = (props: PropsWithChildren<IThesesProviderProps>) => {
     )
     // eslint-disable-next-line @eslint-react/exhaustive-deps -- filters.states/types are tracked via joined keys below to avoid identity-based reruns
   }, [fetchAll, page, limit, sort, filterStatesKey, filterTypesKey, debouncedSearch])
-
-  useEffect(() => {
-    if (!persistState) return
-
-    const params = new URLSearchParams(searchParams)
-
-    const setOrDelete = (key: string, value: string | undefined) => {
-      if (value && value.length > 0) {
-        params.set(key, value)
-      } else {
-        params.delete(key)
-      }
-    }
-
-    setOrDelete('page', page > 0 ? String(page) : undefined)
-    setOrDelete('search', filters.search)
-    setOrDelete('states', filterStatesKey)
-    setOrDelete('types', filterTypesKey)
-    setOrDelete('sortBy', sort.column !== DEFAULT_SORT.column ? sort.column : undefined)
-    setOrDelete('sortOrder', sort.direction !== DEFAULT_SORT.direction ? sort.direction : undefined)
-
-    setSearchParams(params, { replace: true })
-    // eslint-disable-next-line @eslint-react/exhaustive-deps -- searchParams/setSearchParams change on every navigation; only sync URL when actual state changes
-  }, [persistState, page, filters.search, filterStatesKey, filterTypesKey, sort])
 
   const contextState = useMemo<IThesesContext>(() => {
     return {


### PR DESCRIPTION
Reverts ls1intum/thesis-management#1157

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified navigation across tasks, topics, presentations, theses, and applications for more consistent page switching.
  * Removed modifier-key and middle-click behavior from table rows, so clicks now open the selected item directly.
  * Fixed list pages so filters, sorting, and pagination no longer stay in the URL or persist unexpectedly between visits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->