### PR TITLE
Filter topics by supervisor name via shareable URL

### DIFF
--- a/client/e2e/topic/topic-supervisor-filter.spec.ts
+++ b/client/e2e/topic/topic-supervisor-filter.spec.ts
@@ -1,0 +1,76 @@
+import { test, expect } from '@playwright/test'
+import { navigateTo } from '../helpers'
+
+// Seed data (see server/.../seed_dev_test_data.sql):
+//   Topic 1 "Automated Code Review"        supervisor = Supervisor User
+//   Topic 2 "Continuous Integration ..."   supervisors = Supervisor User + Supervisor2 User
+//   Topic 3 "Anomaly Detection ..."        supervisor = Supervisor2 User
+
+test.describe('Topics - Supervisor URL filter', () => {
+  test.use({ storageState: { cookies: [], origins: [] } })
+
+  test('?supervisor= query param filters to matching supervisor only', async ({ page }) => {
+    await navigateTo(page, '/?supervisor=Supervisor%20User')
+
+    await expect(page.getByText(/Topics supervised by Supervisor User/i)).toBeVisible({
+      timeout: 15_000,
+    })
+
+    await expect(page.getByText(/Automated Code Review/i).first()).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByText(/Continuous Integration/i).first()).toBeVisible({ timeout: 5_000 })
+    await expect(page.getByText(/Anomaly Detection/i)).toBeHidden({ timeout: 5_000 })
+  })
+
+  test('/supervisor/:name path route filters the same way', async ({ page }) => {
+    await navigateTo(page, '/supervisor/Supervisor%20User')
+
+    await expect(page.getByText(/Topics supervised by Supervisor User/i)).toBeVisible({
+      timeout: 15_000,
+    })
+
+    await expect(page.getByText(/Automated Code Review/i).first()).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByText(/Continuous Integration/i).first()).toBeVisible({ timeout: 5_000 })
+    await expect(page.getByText(/Anomaly Detection/i)).toBeHidden({ timeout: 5_000 })
+  })
+
+  test('filtering by a different supervisor swaps the visible topics', async ({ page }) => {
+    await navigateTo(page, '/supervisor/Supervisor2%20User')
+
+    await expect(page.getByText(/Topics supervised by Supervisor2 User/i)).toBeVisible({
+      timeout: 15_000,
+    })
+
+    await expect(page.getByText(/Continuous Integration/i).first()).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByText(/Anomaly Detection/i).first()).toBeVisible({ timeout: 5_000 })
+    await expect(page.getByText(/Automated Code Review/i)).toBeHidden({ timeout: 5_000 })
+  })
+
+  test('supervisor filter is case-insensitive', async ({ page }) => {
+    await navigateTo(page, '/?supervisor=supervisor%20user')
+
+    await expect(page.getByText(/Automated Code Review/i).first()).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByText(/Anomaly Detection/i)).toBeHidden({ timeout: 5_000 })
+  })
+
+  test('unknown supervisor name shows no topics', async ({ page }) => {
+    await navigateTo(page, '/supervisor/Nobody%20Here')
+
+    await expect(page.getByText(/Topics supervised by Nobody Here/i)).toBeVisible({
+      timeout: 15_000,
+    })
+
+    // None of the seeded topics should be visible
+    await expect(page.getByText(/Automated Code Review/i)).toBeHidden({ timeout: 5_000 })
+    await expect(page.getByText(/Continuous Integration/i)).toBeHidden({ timeout: 5_000 })
+    await expect(page.getByText(/Anomaly Detection/i)).toBeHidden({ timeout: 5_000 })
+  })
+
+  test('without supervisor filter, all open topics are visible', async ({ page }) => {
+    await navigateTo(page, '/')
+
+    await expect(page.getByText('Find a Thesis Topic')).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByText(/Automated Code Review/i).first()).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByText(/Continuous Integration/i).first()).toBeVisible({ timeout: 5_000 })
+    await expect(page.getByText(/Anomaly Detection/i).first()).toBeVisible({ timeout: 5_000 })
+  })
+})

--- a/client/src/app/Routes.tsx
+++ b/client/src/app/Routes.tsx
@@ -313,6 +313,14 @@ const AppRoutes = () => {
             }
           />
           <Route
+            path='/supervisor/:supervisorName'
+            element={
+              <PublicArea size={publicBreakpointSize}>
+                <LandingPage />
+              </PublicArea>
+            }
+          />
+          <Route
             path='/:researchGroupAbbreviation'
             element={
               <PublicArea size={publicBreakpointSize}>

--- a/client/src/app/pages/LandingPage/LandingPage.tsx
+++ b/client/src/app/pages/LandingPage/LandingPage.tsx
@@ -21,11 +21,16 @@ import { TOPIC_DISCLAIMER_TEXT } from '@/core/topic/components/TopicDisclaimerAl
 const LandingPage = () => {
   usePageTitle('Find a Thesis Topic')
 
-  const { researchGroupAbbreviation } = useParams<{ researchGroupAbbreviation: string }>()
+  const { researchGroupAbbreviation, supervisorName: supervisorNameParam } = useParams<{
+    researchGroupAbbreviation: string
+    supervisorName: string
+  }>()
 
   const [searchParams, setSearchParams] = useSearchParams()
   const [searchKey, setSearchKey] = useState(searchParams.get('search') ?? '')
   const [debouncedSearch] = useDebouncedValue(searchKey, 300)
+
+  const supervisorFilter = supervisorNameParam ?? searchParams.get('supervisor') ?? undefined
 
   const [topicView, setTopicView] = useState<string>(
     searchParams.get('view') ?? GLOBAL_CONFIG.topic_views_options.OPEN,
@@ -69,8 +74,9 @@ const LandingPage = () => {
       researchGroupIds: researchGroupFilter,
       search: debouncedSearch,
       types: selectedThesisTypes,
+      supervisorName: supervisorFilter,
     }),
-    [researchGroupFilter, debouncedSearch, selectedThesisTypes],
+    [researchGroupFilter, debouncedSearch, selectedThesisTypes, supervisorFilter],
   )
 
   useEffect(() => {
@@ -135,6 +141,7 @@ const LandingPage = () => {
         researchGroupId={
           researchGroups.find((group) => group.abbreviation === researchGroupAbbreviation)?.id
         }
+        supervisorName={supervisorFilter}
       />
 
       <Alert variant='light' color='blue' icon={<InfoIcon />} style={{ flexShrink: 0 }}>

--- a/client/src/app/pages/LandingPage/components/LandingPageHeader/LandingPageHeader.tsx
+++ b/client/src/app/pages/LandingPage/components/LandingPageHeader/LandingPageHeader.tsx
@@ -8,9 +8,10 @@ import { getApiResponseErrorMessage } from '@/core/requests/handler'
 
 interface LandingPageHeaderProps {
   researchGroupId?: string
+  supervisorName?: string
 }
 
-const LandingPageHeader = ({ researchGroupId }: LandingPageHeaderProps) => {
+const LandingPageHeader = ({ researchGroupId, supervisorName }: LandingPageHeaderProps) => {
   const computedColorScheme = useComputedColorScheme()
 
   const [researchGroup, setResearchGroup] = useState<IResearchGroup | undefined>()
@@ -34,6 +35,19 @@ const LandingPageHeader = ({ researchGroupId }: LandingPageHeaderProps) => {
     )
   }, [researchGroupId])
 
+  const title = supervisorName
+    ? `Topics supervised by ${supervisorName}`
+    : researchGroup
+      ? researchGroup.name
+      : 'Find a Thesis Topic'
+
+  const subtitle = supervisorName
+    ? `Thesis topics currently offered by ${supervisorName}.`
+    : researchGroup
+      ? researchGroup.description
+      : 'Whether you are looking for inspiration or have a unique idea in mind, ' +
+        'Thesis Management makes it easy. Explore topics posted by instructors or suggest your own.'
+
   return (
     <Card
       radius='md'
@@ -44,14 +58,11 @@ const LandingPageHeader = ({ researchGroupId }: LandingPageHeaderProps) => {
       <Flex justify='flex-start' align='center' gap='xl' wrap='nowrap'>
         <Flex direction='column' gap='xs' flex={1}>
           <Flex justify='space-between' align='flex-start' gap='xs'>
-            <Title order={2}>{researchGroup ? researchGroup.name : 'Find a Thesis Topic'}</Title>
+            <Title order={2}>{title}</Title>
             <LogoCircle size={40} logoSize={30} hiddenFrom='sm' />
           </Flex>
           <Title order={5} c='dimmed'>
-            {researchGroup
-              ? researchGroup.description
-              : 'Whether you are looking for inspiration or have a unique idea in mind, ' +
-                'Thesis Management makes it easy. Explore topics posted by instructors or suggest your own.'}
+            {subtitle}
           </Title>
         </Flex>
 

--- a/client/src/core/topic/providers/TopicsProvider/TopicsProvider.tsx
+++ b/client/src/core/topic/providers/TopicsProvider/TopicsProvider.tsx
@@ -79,6 +79,7 @@ const TopicsProvider = (props: PropsWithChildren<ITopicsProviderProps>) => {
           onlyOwnResearchGroup: filters.researchSpecific ? 'true' : 'false',
           search: filters.search ?? '',
           researchGroupIds: filters.researchGroupIds?.join(',') ?? '',
+          supervisor: filters.supervisorName ?? '',
         },
       },
       (res) => {

--- a/client/src/core/topic/providers/TopicsProvider/context.ts
+++ b/client/src/core/topic/providers/TopicsProvider/context.ts
@@ -9,6 +9,7 @@ export interface ITopicsFilters {
   researchSpecific?: boolean
   search?: string
   researchGroupIds?: string[]
+  supervisorName?: string
 }
 
 export interface ITopicsContext {

--- a/server/src/main/java/de/tum/cit/aet/thesis/core/topic/controller/TopicController.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/core/topic/controller/TopicController.java
@@ -60,6 +60,7 @@ public class TopicController {
 	 * @param sortBy the field to sort by
 	 * @param sortOrder the sort direction (asc or desc)
 	 * @param researchGroupIds the research group IDs to filter by
+	 * @param supervisor the full name of a supervisor to filter by (case-insensitive)
 	 * @return the paginated list of topics
 	 */
 	@GetMapping
@@ -72,7 +73,8 @@ public class TopicController {
 			@RequestParam(required = false, defaultValue = "50") Integer limit,
 			@RequestParam(required = false, defaultValue = "createdAt") String sortBy,
 			@RequestParam(required = false, defaultValue = "desc") String sortOrder,
-			@RequestParam(required = false, defaultValue = "") UUID[] researchGroupIds
+			@RequestParam(required = false, defaultValue = "") UUID[] researchGroupIds,
+			@RequestParam(required = false) String supervisor
 	) {
 		limit = RequestValidator.clampPageSize(limit);
 		Page<Topic> topics = topicService.getAll(
@@ -84,7 +86,8 @@ public class TopicController {
 				limit,
 				sortBy,
 				sortOrder,
-				researchGroupIds
+				researchGroupIds,
+				supervisor
 		);
 
 		return ResponseEntity.ok(PaginationDto.fromSpringPage(topics.map(TopicOverviewDto::fromTopicEntity)));

--- a/server/src/main/java/de/tum/cit/aet/thesis/core/topic/repository/TopicRepository.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/core/topic/repository/TopicRepository.java
@@ -18,6 +18,13 @@ public interface TopicRepository extends JpaRepository<Topic, UUID> {
 			SELECT t.* FROM topics t WHERE ( :researchGroupIds IS NULL OR t.research_group_id IN (:researchGroupIds)) AND
 					(:searchQuery IS NULL OR t.title ILIKE CONCAT('%', :searchQuery, '%')) AND
 					(t.thesis_types IS NULL OR CAST(:types AS TEXT[]) IS NULL OR t.thesis_types && CAST(:types AS TEXT[])) AND
+					(:supervisorName IS NULL OR EXISTS (
+						SELECT 1 FROM topic_roles tr
+						JOIN users u ON u.user_id = tr.user_id
+						WHERE tr.topic_id = t.topic_id
+							AND tr.role = 'SUPERVISOR'
+							AND LOWER(TRIM(COALESCE(u.first_name, '') || ' ' || COALESCE(u.last_name, ''))) = LOWER(TRIM(:supervisorName))
+					)) AND
 					(
 						CAST(:states AS TEXT[]) IS NULL
 						OR (
@@ -35,6 +42,7 @@ public interface TopicRepository extends JpaRepository<Topic, UUID> {
 			@Param("types") String[] types,
 			@Param("states") String[] states,
 			@Param("searchQuery") String searchQuery,
+			@Param("supervisorName") String supervisorName,
 			Pageable page
 	);
 

--- a/server/src/main/java/de/tum/cit/aet/thesis/core/topic/service/TopicService.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/core/topic/service/TopicService.java
@@ -87,6 +87,7 @@ public class TopicService {
 	 * @param sortBy the field to sort by
 	 * @param sortOrder the sort direction (asc or desc)
 	 * @param researchGroupIds the research group IDs to filter by
+	 * @param supervisorName the full name ("first last") of a supervisor to filter by, case-insensitive
 	 * @return a page of topics matching the filters
 	 */
 	public Page<Topic> getAll(
@@ -98,7 +99,8 @@ public class TopicService {
 			int limit,
 			String sortBy,
 			String sortOrder,
-			UUID[] researchGroupIds
+			UUID[] researchGroupIds,
+			String supervisorName
 	) {
 		Sort.Order order = new Sort.Order(
 				sortOrder.equals("asc") ? Sort.Direction.ASC : Sort.Direction.DESC,
@@ -120,6 +122,9 @@ public class TopicService {
 		}
 		String[] statesFilter = (states != null && states.length > 0) ? states : new String[] { TopicState.OPEN.name() };
 
+		String supervisorNameFilter = (supervisorName == null || supervisorName.isBlank())
+				? null : supervisorName.trim();
+
 		return topicRepository.searchTopics(
 				researchGroup == null
 						? (researchGroupIds == null ? null
@@ -128,6 +133,7 @@ public class TopicService {
 				typesFilter,
 				statesFilter,
 				searchQueryFilter,
+				supervisorNameFilter,
 				PageRequest.of(page, limit, Sort.by(order))
 		);
 	}
@@ -177,6 +183,7 @@ public class TopicService {
 				Collections.singleton(researchGroupId),
 				null,
 				new String[] { TopicState.OPEN.name() },
+				null,
 				null,
 				PageRequest.of(0, Integer.MAX_VALUE, Sort.unsorted())
 		).toList();

--- a/server/src/test/java/de/tum/cit/aet/thesis/core/topic/controller/TopicControllerTest.java
+++ b/server/src/test/java/de/tum/cit/aet/thesis/core/topic/controller/TopicControllerTest.java
@@ -535,4 +535,143 @@ class TopicControllerTest extends BaseIntegrationTest {
 			assertThat(json.get("content").size()).isGreaterThanOrEqualTo(1);
 		}
 	}
+
+	@Nested
+	class TopicSupervisorFiltering {
+		// Test users are created with given_name = family_name = universityId,
+		// so a supervisor's full name reads as "<universityId> <universityId>".
+		private String fullName(TestUser user) {
+			return user.universityId() + " " + user.universityId();
+		}
+
+		private UUID createTopicWithSupervisor(String title, TestUser supervisor, UUID researchGroupId) throws Exception {
+			ReplaceTopicPayload payload = new ReplaceTopicPayload(
+					title, Set.of("MASTER"),
+					"PS", "Req", "Goals", "Refs",
+					List.of(supervisor.userId()), List.of(supervisor.userId()),
+					researchGroupId, null, null, false
+			);
+			String response = mockMvc.perform(MockMvcRequestBuilders.post("/v2/topics")
+							.header("Authorization", createRandomAdminAuthentication())
+							.contentType(MediaType.APPLICATION_JSON)
+							.content(objectMapper.writeValueAsString(payload)))
+					.andExpect(status().isOk())
+					.andReturn().getResponse().getContentAsString();
+			return UUID.fromString(objectMapper.readTree(response).get("topicId").asString());
+		}
+
+		@Test
+		void getTopics_FilterBySupervisorName_ReturnsOnlyMatchingTopics() throws Exception {
+			TestUser advisorA = createRandomTestUser(List.of("supervisor", "advisor"));
+			TestUser advisorB = createRandomTestUser(List.of("supervisor", "advisor"));
+			UUID rg = createTestResearchGroup("Supervisor Filter Group", advisorA.universityId());
+
+			UUID topicIdA = createTopicWithSupervisor("Advisor A Topic", advisorA, rg);
+			createTopicWithSupervisor("Advisor B Topic", advisorB, rg);
+
+			String response = mockMvc.perform(MockMvcRequestBuilders.get("/v2/topics")
+							.header("Authorization", createRandomAdminAuthentication())
+							.param("supervisor", fullName(advisorA)))
+					.andExpect(status().isOk())
+					.andReturn().getResponse().getContentAsString();
+
+			JsonNode json = objectMapper.readTree(response);
+			assertThat(json.get("content").size()).isEqualTo(1);
+			assertThat(json.get("content").get(0).get("topicId").asString())
+					.isEqualTo(topicIdA.toString());
+		}
+
+		@Test
+		void getTopics_FilterBySupervisorName_IsCaseInsensitiveAndTrimmed() throws Exception {
+			TestUser advisor = createRandomTestUser(List.of("supervisor", "advisor"));
+			UUID rg = createTestResearchGroup("Supervisor Case Group", advisor.universityId());
+
+			createTopicWithSupervisor("Case Insensitive Topic", advisor, rg);
+
+			String response = mockMvc.perform(MockMvcRequestBuilders.get("/v2/topics")
+							.header("Authorization", createRandomAdminAuthentication())
+							.param("supervisor", "  " + fullName(advisor).toUpperCase() + "  "))
+					.andExpect(status().isOk())
+					.andReturn().getResponse().getContentAsString();
+
+			JsonNode json = objectMapper.readTree(response);
+			assertThat(json.get("content").size()).isEqualTo(1);
+			assertThat(json.get("content").get(0).get("title").asString())
+					.isEqualTo("Case Insensitive Topic");
+		}
+
+		@Test
+		void getTopics_FilterBySupervisorName_UnknownName_ReturnsEmpty() throws Exception {
+			TestUser advisor = createRandomTestUser(List.of("supervisor", "advisor"));
+			UUID rg = createTestResearchGroup("Supervisor NoMatch Group", advisor.universityId());
+			createTopicWithSupervisor("Some Topic", advisor, rg);
+
+			mockMvc.perform(MockMvcRequestBuilders.get("/v2/topics")
+							.header("Authorization", createRandomAdminAuthentication())
+							.param("supervisor", "Nobody Here"))
+					.andExpect(status().isOk())
+					// DTOs use @JsonInclude(NON_EMPTY) so empty content arrays are omitted entirely
+					.andExpect(jsonPath("$.totalElements").value(0));
+		}
+
+		@Test
+		void getTopics_FilterBySupervisorName_MatchesTopicsWithMultipleSupervisors() throws Exception {
+			TestUser advisorA = createRandomTestUser(List.of("supervisor", "advisor"));
+			TestUser advisorB = createRandomTestUser(List.of("supervisor", "advisor"));
+			UUID rg = createTestResearchGroup("Multi Supervisor Group", advisorA.universityId());
+
+			// Topic with both A and B as supervisors
+			ReplaceTopicPayload payload = new ReplaceTopicPayload(
+					"Shared Topic", Set.of("MASTER"),
+					"PS", "Req", "Goals", "Refs",
+					List.of(advisorA.userId()),
+					List.of(advisorA.userId(), advisorB.userId()),
+					rg, null, null, false
+			);
+			mockMvc.perform(MockMvcRequestBuilders.post("/v2/topics")
+							.header("Authorization", createRandomAdminAuthentication())
+							.contentType(MediaType.APPLICATION_JSON)
+							.content(objectMapper.writeValueAsString(payload)))
+					.andExpect(status().isOk());
+
+			// Filtering by either A or B should find the shared topic
+			for (TestUser supervisor : List.of(advisorA, advisorB)) {
+				String response = mockMvc.perform(MockMvcRequestBuilders.get("/v2/topics")
+								.header("Authorization", createRandomAdminAuthentication())
+								.param("supervisor", fullName(supervisor)))
+						.andExpect(status().isOk())
+						.andReturn().getResponse().getContentAsString();
+				JsonNode json = objectMapper.readTree(response);
+				assertThat(json.get("content").size()).isEqualTo(1);
+				assertThat(json.get("content").get(0).get("title").asString()).isEqualTo("Shared Topic");
+			}
+		}
+
+		@Test
+		void getTopics_FilterBySupervisorName_IgnoresExaminerOnlyMatches() throws Exception {
+			TestUser examiner = createRandomTestUser(List.of("supervisor"));
+			TestUser advisor = createRandomTestUser(List.of("supervisor", "advisor"));
+			UUID rg = createTestResearchGroup("Examiner Only Group", advisor.universityId());
+
+			// examiner is only in the EXAMINER role, advisor is the SUPERVISOR
+			ReplaceTopicPayload payload = new ReplaceTopicPayload(
+					"Examiner Only Topic", Set.of("MASTER"),
+					"PS", "Req", "Goals", "Refs",
+					List.of(examiner.userId()),
+					List.of(advisor.userId()),
+					rg, null, null, false
+			);
+			mockMvc.perform(MockMvcRequestBuilders.post("/v2/topics")
+							.header("Authorization", createRandomAdminAuthentication())
+							.contentType(MediaType.APPLICATION_JSON)
+							.content(objectMapper.writeValueAsString(payload)))
+					.andExpect(status().isOk());
+
+			mockMvc.perform(MockMvcRequestBuilders.get("/v2/topics")
+							.header("Authorization", createRandomAdminAuthentication())
+							.param("supervisor", fullName(examiner)))
+					.andExpect(status().isOk())
+					.andExpect(jsonPath("$.totalElements").value(0));
+		}
+	}
 }

--- a/server/src/test/java/de/tum/cit/aet/thesis/core/topic/service/TopicServiceTest.java
+++ b/server/src/test/java/de/tum/cit/aet/thesis/core/topic/service/TopicServiceTest.java
@@ -83,6 +83,7 @@ class TopicServiceTest {
 				any(),
 				any(),
 				any(),
+				any(),
 				any(PageRequest.class)
 		)).thenReturn(expectedPage);
 
@@ -95,6 +96,7 @@ class TopicServiceTest {
 				10,
 				"title",
 				"asc",
+				null,
 				null
 		);
 
@@ -104,6 +106,7 @@ class TopicServiceTest {
 				eq(null),
 				eq(null),
 				eq(new String[] { TopicState.OPEN.name()}),
+				eq(null),
 				eq(null),
 				eq(PageRequest.of(0, 10, Sort.by(Sort.Direction.ASC, "title")))
 		);


### PR DESCRIPTION
## Summary
- Adds a supervisor-scoped view of the public topic listing so supervisors can send a link that only shows their open topics.
- New `?supervisor=<full name>` query param and `/supervisor/:name` path route on the landing page. Matching is case-insensitive, whitespace-tolerant, and restricted to the SUPERVISOR role on a topic.
- Header switches to "Topics supervised by X" when the view is scoped.

## Details
- Backend: threads `supervisorName` through `TopicController` → `TopicService` → `TopicRepository.searchTopics` via an `EXISTS` clause on `topic_roles` joined with `users`.
- Client: adds `supervisorName` to `ITopicsFilters`, reads both the query param and the new path param on the landing page, and adds a `/supervisor/:supervisorName` route.
- Example shareable link: `https://thesis.aet.cit.tum.de/supervisor/Mateo%20de%20Mayo` or `https://thesis.aet.cit.tum.de/?supervisor=Mateo%20de%20Mayo`.

## Test plan
- [x] Server: 5 new integration tests in `TopicControllerTest.TopicSupervisorFiltering` cover basic filtering, case-insensitivity + trimming, unknown name → empty, multi-supervisor topic match, and that examiner-only role matches are excluded (all pass locally).
- [x] Server: existing `TopicServiceTest.getAll_ReturnsPageOfTopics` updated for the new arg (passes).
- [x] Client: `pnpm exec tsc --noEmit` and `pnpm exec eslint` on edited files are clean.
- [x] E2E: new Playwright spec `client/e2e/topic/topic-supervisor-filter.spec.ts` covers query param, path route, case-insensitivity, unknown name, and unfiltered baseline. Run via `./execute-e2e-local.sh`.
- [x] Manual: visit `/supervisor/Supervisor%20User` on the seeded dev instance and confirm only the ASE topics with that supervisor appear, and the header reads "Topics supervised by Supervisor User".

Closes #1159

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Topics can now be filtered by supervisor in the app, including a new supervisor-specific page route.
  * The page header now updates to show supervisor-related messaging when a supervisor filter is present.

* **Bug Fixes**
  * Supervisor filtering is case-insensitive and ignores extra whitespace.
  * Topics now correctly reflect the selected supervisor, including cases with no matches or multiple supervisors.

* **Tests**
  * Added end-to-end and server-side coverage for supervisor-based topic filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Screenshots

![Supervisor topic filter](https://raw.githubusercontent.com/Claudia-Anthropica/pr-screenshots/main/5dae72fa-d20d-42c3-8e2e-10edf833afc0.png)
