### PR TITLE
Switch docs site to docs.thesis.aet.cit.tum.de custom domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ Thesis Management was developed as part of multiple bachelor's and master's thes
 
 ## Documentation
 
-The full documentation lives at **[ls1intum.github.io/thesis-management](https://ls1intum.github.io/thesis-management/)**. It contains role-based guides with embedded video walk-throughs, permission matrices, workflow diagrams, and everything an operator or developer needs to run the platform.
+The full documentation lives at **[docs.thesis.aet.cit.tum.de](https://docs.thesis.aet.cit.tum.de/)**. It contains role-based guides with embedded video walk-throughs, permission matrices, workflow diagrams, and everything an operator or developer needs to run the platform.
 
-- **[Students](https://ls1intum.github.io/thesis-management/students/)** — apply for a topic, book interview slots, write your thesis, and receive your grade.
-- **[Supervisors & Examiners](https://ls1intum.github.io/thesis-management/supervisors/)** — create topics, review applications, run interviews, supervise theses, and issue grades. Includes the full [Permissions](https://ls1intum.github.io/thesis-management/supervisors/permissions) matrix and the [Workflows](https://ls1intum.github.io/thesis-management/supervisors/workflows) flowcharts.
-- **[Admins](https://ls1intum.github.io/thesis-management/admin/)** — configuration, production setup, and data retention.
-- **[Developers](https://ls1intum.github.io/thesis-management/developer/)** — local development, database migrations, mail templates, release workflow, and the API reference.
+- **[Students](https://docs.thesis.aet.cit.tum.de/students/)** — apply for a topic, book interview slots, write your thesis, and receive your grade.
+- **[Supervisors & Examiners](https://docs.thesis.aet.cit.tum.de/supervisors/)** — create topics, review applications, run interviews, supervise theses, and issue grades. Includes the full [Permissions](https://docs.thesis.aet.cit.tum.de/supervisors/permissions) matrix and the [Workflows](https://docs.thesis.aet.cit.tum.de/supervisors/workflows) flowcharts.
+- **[Admins](https://docs.thesis.aet.cit.tum.de/admin/)** — configuration, production setup, and data retention.
+- **[Developers](https://docs.thesis.aet.cit.tum.de/developer/)** — local development, database migrations, mail templates, release workflow, and the API reference.
 
-> **Just want a demo?** Run `docker compose -f docker-compose.showcase.yml up -d` and open <http://localhost:3100>. See the [Development Setup](https://ls1intum.github.io/thesis-management/developer/development-setup) guide for details.
+> **Just want a demo?** Run `docker compose -f docker-compose.showcase.yml up -d` and open <http://localhost:3100>. See the [Development Setup](https://docs.thesis.aet.cit.tum.de/developer/development-setup) guide for details.
 
 ## Building the documentation locally
 

--- a/client/src/core/components/Footer/Footer.tsx
+++ b/client/src/core/components/Footer/Footer.tsx
@@ -5,6 +5,8 @@ import { Link } from 'react-router'
 import packageJson from '@/../package.json'
 import { labelByEnvironment } from '@/core/components/EnvironmentBanner/EnvironmentBanner'
 
+const DOCS_URL = 'https://docs.thesis.aet.cit.tum.de'
+
 const links = [
   { link: '/about', label: 'About', visible: true },
   { link: '/imprint', label: 'Imprint', visible: true },
@@ -56,6 +58,9 @@ const Footer = (props: IFooterProps) => {
           justify='center'
           align='center'
         >
+          <Anchor href={DOCS_URL} target='_blank' c='dimmed'>
+            Docs
+          </Anchor>
           {links
             .filter((link) => link.visible)
             .map((link) => (

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -1,8 +1,9 @@
 # Documentation
 
 The user-facing documentation site for Thesis Management, built with
-[Docusaurus](https://docusaurus.io/). It is published to GitHub Pages at
-<https://ls1intum.github.io/thesis-management/>.
+[Docusaurus](https://docusaurus.io/). It is published to GitHub Pages under
+the custom domain <https://docs.thesis.aet.cit.tum.de/> (see
+`static/CNAME`).
 
 ## Prerequisites
 

--- a/documentation/docusaurus.config.ts
+++ b/documentation/docusaurus.config.ts
@@ -15,10 +15,9 @@ const config: Config = {
   },
 
   // Set the production url of your site here
-  url: 'https://ls1intum.github.io',
+  url: 'https://docs.thesis.aet.cit.tum.de',
   // Set the /<baseUrl>/ pathname under which your site is served
-  // For GitHub pages deployment, it is often '/<projectName>/'
-  baseUrl: '/thesis-management/',
+  baseUrl: '/',
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.

--- a/documentation/static/CNAME
+++ b/documentation/static/CNAME
@@ -1,0 +1,1 @@
+docs.thesis.aet.cit.tum.de


### PR DESCRIPTION
## Summary
- Update Docusaurus `url` → `https://docs.thesis.aet.cit.tum.de` and `baseUrl` → `/` (was `/thesis-management/`), and add `documentation/static/CNAME` so GitHub Pages serves the docs under the new custom domain.
- Refresh all `ls1intum.github.io/thesis-management` links in `README.md` and `documentation/README.md`.
- Add a **Docs** link to the app footer (`client/src/core/components/Footer/Footer.tsx`), opening the new docs site in a new tab.

## Prerequisites for this to serve correctly
- DNS `CNAME`: `docs.thesis.aet.cit.tum.de` → `ls1intum.github.io`
- Custom domain configured under GitHub Pages settings for this repo

## Test plan
- [ ] `documentation/`: `pnpm build` succeeds
- [ ] After deploy, https://docs.thesis.aet.cit.tum.de/ serves the site and old GH-Pages URL no longer 404s intra-site links
- [ ] App footer shows a "Docs" link that opens the new domain in a new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Docs” link to the application footer, opening documentation in a new tab.

* **Documentation**
  * Updated documentation links to use the new custom domain.
  * Configured the documentation site to use the custom domain at its root URL.
  * Updated documentation hosting information and domain configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->