### PR TITLE
Fix build-server CI failure: remove pnpm cache from setup-node

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -95,8 +95,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '24.18.0'
-          cache: 'pnpm'
-          cache-dependency-path: 'client/pnpm-lock.yaml'
 
       # `pnpm sbom --lockfile-only` reads the lockfile directly, so we
       # deliberately do NOT run `pnpm install` — skipping it saves time


### PR DESCRIPTION
## Summary

`build-dev-container / build-server` in `dev.yml` fails on every PR that touches `server/` — including #1198 and the earlier `renovate/undici` run. The actual build+push succeeds; the failure is entirely in the post-step of `actions/setup-node@v6`:

```
##[error]Path Validation Error: Path(s) specified in the action for
caching do(es) not exist, hence no cache is being saved.
```

### Root cause

`build_docker.yml` sets `cache: 'pnpm'` on setup-node, but the very next block **deliberately skips `pnpm install`** — the SBOM generator uses `pnpm sbom --lockfile-only` and reads the lockfile directly (per the existing comment). Because `pnpm install` never runs, the pnpm store directory doesn't exist, and `setup-node@v6` treats a missing cache path as a hard error (older versions just warned).

The bug was introduced in #1167 (2026-07-07, "Remove SBOM caching in repo"), which stopped running `pnpm install` here but left the `cache: 'pnpm'` config in place. It only fires when the changed-files guard triggers, i.e. server-touching PRs — client-only PRs since then have all passed.

### Fix

Drop `cache: 'pnpm'` and `cache-dependency-path` from the setup-node step. Nothing installs, so there is nothing to cache.

## Test plan

- [ ] `build-dev-container / build-server` passes on this PR (which touches `server/` via workflow files — wait, workflow-only, so the guard may skip; verify by watching a server-touching PR rebase onto this)
- [ ] Rebase #1198 on this fix and confirm the build-server job goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)