### PR TITLE
Accept Resource in AbstractAutoFillService, matching PDF extractor

### DIFF
--- a/server/src/main/java/de/tum/cit/aet/thesis/thesis/service/AbstractAutoFillService.java
+++ b/server/src/main/java/de/tum/cit/aet/thesis/thesis/service/AbstractAutoFillService.java
@@ -3,11 +3,13 @@ package de.tum.cit.aet.thesis.thesis.service;
 import de.tum.cit.aet.thesis.core.utility.AbstractExtractor;
 import de.tum.cit.aet.thesis.thesis.constants.ThesisAbstractSource;
 import de.tum.cit.aet.thesis.thesis.entity.Thesis;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.io.InputStream;
 
 /**
  * Applies an extracted abstract to a thesis. A confident extraction into an empty abstract is
@@ -29,10 +31,31 @@ public class AbstractAutoFillService {
 	 */
 	public void process(Thesis thesis, MultipartFile file) {
 		try {
-			apply(thesis, AbstractExtractor.extract(file.getBytes()));
+			process(thesis, file.getBytes());
 		} catch (Exception e) {
 			log.warn("Abstract extraction failed for thesis {}: {}", thesis.getId(), e.getMessage());
 		}
+	}
+
+	/**
+	 * Extracts the abstract from a PDF loaded via a Spring {@link Resource} (e.g. an already-
+	 * stored thesis or proposal file) and applies it to the thesis. Mirrors
+	 * {@link #process(Thesis, MultipartFile)} so callers that only hold a stored-file resource
+	 * (like the AI review pipeline) can trigger abstract auto-fill against the same file.
+	 *
+	 * @param thesis the thesis to update (mutated in place; the caller persists it)
+	 * @param resource the stored proposal or thesis PDF resource
+	 */
+	public void process(Thesis thesis, Resource resource) {
+		try (InputStream in = resource.getInputStream()) {
+			process(thesis, in.readAllBytes());
+		} catch (Exception e) {
+			log.warn("Abstract extraction failed for thesis {}: {}", thesis.getId(), e.getMessage());
+		}
+	}
+
+	private void process(Thesis thesis, byte[] pdfBytes) {
+		apply(thesis, AbstractExtractor.extract(pdfBytes));
 	}
 
 	/**

--- a/server/src/test/java/de/tum/cit/aet/thesis/thesis/service/AbstractAutoFillServiceTest.java
+++ b/server/src/test/java/de/tum/cit/aet/thesis/thesis/service/AbstractAutoFillServiceTest.java
@@ -13,6 +13,7 @@ import de.tum.cit.aet.thesis.core.utility.AbstractExtractor;
 import de.tum.cit.aet.thesis.thesis.constants.ThesisAbstractSource;
 import de.tum.cit.aet.thesis.thesis.entity.Thesis;
 import org.junit.jupiter.api.Test;
+import org.springframework.core.io.ByteArrayResource;
 import org.springframework.mock.web.MockMultipartFile;
 
 import java.io.ByteArrayOutputStream;
@@ -131,6 +132,33 @@ class AbstractAutoFillServiceTest {
 		assertThat(thesis.getAbstractSource()).isEqualTo(ThesisAbstractSource.EXTRACTED);
 		assertThat(thesis.getAbstractField())
 				.isEqualTo("<p>This is a clearly extractable abstract for the thesis document.</p>");
+	}
+
+	@Test
+	void process_confidentResource_autoFillsFromStoredFile() {
+		// Mirrors the AI review pipeline shape: the caller only has a Spring Resource of the
+		// already-stored PDF, not the original MultipartFile. The Resource overload lets abstract
+		// autofill run against that stored file with the same result.
+		Thesis thesis = thesisWith("", ThesisAbstractSource.MANUAL);
+		ByteArrayResource resource = new ByteArrayResource(buildConfidentPdf());
+
+		service.process(thesis, resource);
+
+		assertThat(thesis.getAbstractSource()).isEqualTo(ThesisAbstractSource.EXTRACTED);
+		assertThat(thesis.getAbstractField())
+				.isEqualTo("<p>This is a clearly extractable abstract for the thesis document.</p>");
+	}
+
+	@Test
+	void process_unreadableResource_isNoOp() {
+		Thesis thesis = thesisWith("<p>Existing.</p>", ThesisAbstractSource.MANUAL);
+		ByteArrayResource resource = new ByteArrayResource("not a real pdf".getBytes());
+
+		service.process(thesis, resource);
+
+		assertThat(thesis.getAbstractField()).isEqualTo("<p>Existing.</p>");
+		assertThat(thesis.getAbstractSource()).isEqualTo(ThesisAbstractSource.MANUAL);
+		assertThat(thesis.getAbstractSuggestion()).isNull();
 	}
 
 	@Test


### PR DESCRIPTION
## Summary
- Mirror the `MultipartFile` / `Resource` dual-entry pattern of `feedback/PdfService` in `AbstractAutoFillService`. The existing `MultipartFile` overload keeps working; a new `process(Thesis, Resource)` overload lets callers that only hold a stored-file `Resource` (e.g. the AI review pipeline's `loadPdfResource`) run abstract auto-fill against the persisted PDF without needing the original multipart.
- Both overloads route through a private byte-based path so the extractor call site stays a single line, matching `PdfService`'s shape.
- Adds two tests covering the `Resource` overload: a confident-fill case from a stored PDF and an unreadable-resource no-op.

Base branch is `feat/persist-ai-feedback` (not `develop`) because the AI review pipeline is the motivating consumer for the `Resource` overload.

## Test plan
- [ ] `cd server && ./gradlew test --tests AbstractAutoFillServiceTest` (all 11 tests pass locally)
- [ ] Verify existing `ThesisService.uploadProposal` / `uploadThesisFile` callers still pass a `MultipartFile` and continue to work unchanged
- [ ] Confirm no callers were broken by the overload resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)